### PR TITLE
Replace `ChunkContainerFn` trait object with function pointer

### DIFF
--- a/crates/krilla/src/object/color.rs
+++ b/crates/krilla/src/object/color.rs
@@ -292,7 +292,7 @@ impl GenericICCProfile {
 
 impl Cacheable for GenericICCProfile {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.icc_profiles)
+        |cc| &mut cc.icc_profiles
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {
@@ -334,7 +334,7 @@ impl<const C: u8> ICCProfile<C> {
 
 impl<const C: u8> Cacheable for ICCProfile<C> {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.icc_profiles)
+        |cc| &mut cc.icc_profiles
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {
@@ -356,7 +356,7 @@ pub(crate) struct ICCBasedColorSpace<const C: u8>(pub(crate) ICCProfile<C>);
 
 impl<const C: u8> Cacheable for ICCBasedColorSpace<C> {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.color_spaces)
+        |cc| &mut cc.color_spaces
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {

--- a/crates/krilla/src/object/embed.rs
+++ b/crates/krilla/src/object/embed.rs
@@ -48,7 +48,7 @@ pub struct EmbeddedFile {
 
 impl Cacheable for EmbeddedFile {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.embedded_files)
+        |cc| &mut cc.embedded_files
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {

--- a/crates/krilla/src/object/ext_g_state.rs
+++ b/crates/krilla/src/object/ext_g_state.rs
@@ -105,7 +105,7 @@ impl ExtGState {
 
 impl Cacheable for ExtGState {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.ext_g_states)
+        |cc| &mut cc.ext_g_states
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {

--- a/crates/krilla/src/object/mask.rs
+++ b/crates/krilla/src/object/mask.rs
@@ -97,7 +97,7 @@ impl MaskType {
 
 impl Cacheable for Mask {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.masks)
+        |cc| &mut cc.masks
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {

--- a/crates/krilla/src/object/mod.rs
+++ b/crates/krilla/src/object/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod shading_pattern;
 pub(crate) mod tiling_pattern;
 pub(crate) mod xobject;
 
-pub(crate) type ChunkContainerFn = Box<dyn FnMut(&mut ChunkContainer) -> &mut Vec<Chunk>>;
+pub(crate) type ChunkContainerFn = fn(&mut ChunkContainer) -> &mut Vec<Chunk>;
 
 pub(crate) trait Cacheable: SipHashable {
     fn chunk_container(&self) -> ChunkContainerFn;

--- a/crates/krilla/src/object/shading_function.rs
+++ b/crates/krilla/src/object/shading_function.rs
@@ -233,7 +233,7 @@ impl ShadingFunction {
 
 impl Cacheable for ShadingFunction {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.shading_functions)
+        |cc| &mut cc.shading_functions
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {

--- a/crates/krilla/src/object/shading_pattern.rs
+++ b/crates/krilla/src/object/shading_pattern.rs
@@ -42,7 +42,7 @@ impl ShadingPattern {
 
 impl Cacheable for ShadingPattern {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.patterns)
+        |cc| &mut cc.patterns
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {

--- a/crates/krilla/src/object/tiling_pattern.rs
+++ b/crates/krilla/src/object/tiling_pattern.rs
@@ -73,7 +73,7 @@ impl TilingPattern {
 
 impl Cacheable for TilingPattern {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.patterns)
+        |cc| &mut cc.patterns
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {

--- a/crates/krilla/src/object/xobject.rs
+++ b/crates/krilla/src/object/xobject.rs
@@ -47,7 +47,7 @@ impl XObject {
 
 impl Cacheable for XObject {
     fn chunk_container(&self) -> ChunkContainerFn {
-        Box::new(|cc| &mut cc.x_objects)
+        |cc| &mut cc.x_objects
     }
 
     fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Chunk {

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -514,7 +514,7 @@ impl SerializeContext {
         T: Cacheable,
     {
         self.register_cached(object, |sc, object, root_ref| {
-            let mut chunk_container_fn = object.chunk_container();
+            let chunk_container_fn = object.chunk_container();
             let chunk = object.serialize(sc, root_ref);
             chunk_container_fn(&mut sc.chunk_container).push(chunk);
         })


### PR DESCRIPTION
There seems to be no need for a trait object in `ChunkContainerFn`, since it's a simple projection to a struct field.

While the `Box<dyn Fn(..)>` doesn't actually allocate (which is what I first thought) when created from a bare function pointer, it [does have slight overhead](https://users.rust-lang.org/t/difference-between-box-dyn-fn-arg-res-and-fn-arg-res/72060/3) and is just not really necessary.