### PR TITLE
Fix generation of CIDSet

### DIFF
--- a/crates/krilla/src/object/font/cid_font.rs
+++ b/crates/krilla/src/object/font/cid_font.rs
@@ -156,7 +156,7 @@ impl CIDFont {
             let subsetted_ref = skrifa::FontRef::new(data).map_err(|_| {
                 KrillaError::FontError(self.font.clone(), "failed to read font subset".to_string())
             })?;
-            
+
             num_glyphs = subsetted_ref.maxp().map(|m| m.num_glyphs()).map_err(|_| {
                 KrillaError::FontError(self.font.clone(), "failed to read font subset".to_string())
             })?;

--- a/refs/snapshots/complex_text_3.txt
+++ b/refs/snapshots/complex_text_3.txt
@@ -43,7 +43,7 @@ endobj
   /Filter [/ASCIIHexDecode /FlateDecode]
 >>
 stream
-789CFBFFFFFF010009BB03BE
+789CFBFFFFFF030009DB03DE
 endstream
 endobj
 
@@ -390,7 +390,7 @@ trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(ZR/PrGkMYfu53f3KMJKvpA==) (ZR/PrGkMYfu53f3KMJKvpA==)]
+  /ID [(IQ2V2o/8811qKiJcD0xx/Q==) (IQ2V2o/8811qKiJcD0xx/Q==)]
 >>
 startxref
 9994


### PR DESCRIPTION
We took the number of glyphs in the glyph remapper, but those don't actually have all the glyphs that will be in the final font because composite glyphs might add additional glyphs. Because of this, we just use the value from the parsed subset.