### PR TITLE
Bump pdf-writer and switch back to typst/pdf-writer repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,8 +1115,8 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pdf-writer"
-version = "0.12.0"
-source = "git+https://github.com/LaurenzV/pdf-writer?rev=f95a19c#f95a19c07a1b3e3ee021c1199e91f19badb57d46"
+version = "0.12.1"
+source = "git+https://github.com/typst/pdf-writer?rev=0d513b9#0d513b9050d2f1a0507cabb4898aca971af6da98"
 dependencies = [
  "bitflags 2.6.0",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ once_cell = "1.19.0"
 oxipng = "9.1.2"
 parley = { git = "https://github.com/linebender/parley", rev = "14070d5" }
 paste = "1.0.15"
-pdf-writer = { git = "https://github.com/LaurenzV/pdf-writer", rev = "f95a19c" }
+pdf-writer = { git = "https://github.com/typst/pdf-writer", rev = "0d513b9" }
 proc-macro2 = "1.0.86"
 quote = "1.0.37"
 rayon = "1.10.0"

--- a/crates/krilla/src/content.rs
+++ b/crates/krilla/src/content.rs
@@ -81,7 +81,7 @@ impl ContentBuilder {
         sc.register_limits(buf.limits());
 
         Stream::new(
-            buf.to_bytes(),
+            buf.to_vec(),
             self.bbox
                 .unwrap_or(Rect::from_xywh(0.0, 0.0, 1.0, 1.0).unwrap()),
             self.validation_errors.into_iter().collect(),


### PR DESCRIPTION
Unblocks usage of the `GlyphId` trait in https://github.com/LaurenzV/krilla/pull/169