### PR TITLE
Remove the `PaintMode` struct and prohibit arbitrary-colored outline glyphs for Type3 fonts

### DIFF
--- a/crates/krilla/src/content.rs
+++ b/crates/krilla/src/content.rs
@@ -10,6 +10,7 @@ use pdf_writer::types::TextRenderingMode;
 use pdf_writer::{Content, Finish, Name, Str, TextStr};
 use tiny_skia_path::{Path, PathSegment};
 
+use crate::color::rgb;
 use crate::configure::ValidationError;
 #[cfg(feature = "raster-images")]
 use crate::geom::Size;
@@ -33,7 +34,7 @@ use crate::resource::{Resource, ResourceDictionaryBuilder};
 use crate::serialize::{MaybeDeviceColorSpace, SerializeContext};
 use crate::stream::Stream;
 use crate::text::group::{use_text_spanner, GlyphGroup, GlyphGrouper, GlyphSpan, GlyphSpanner};
-use crate::text::type3::CoveredGlyph;
+use crate::text::type3::ColoredGlyph;
 use crate::text::{Font, FontContainer, FontIdentifier, PaintMode, PdfFont, PDF_UNITS_PER_EM};
 use crate::text::{Glyph, GlyphId};
 use crate::util::{calculate_stroke_bbox, NameExt};
@@ -348,6 +349,7 @@ impl ContentBuilder {
         sc: &mut SerializeContext,
         fill: Option<&Fill>,
         stroke: Option<&Stroke>,
+        context_color: rgb::Color,
         glyphs: &[impl Glyph],
         font: Font,
         text: &str,
@@ -428,7 +430,7 @@ impl ContentBuilder {
                     },
                     glyphs,
                     font.clone(),
-                    PaintMode::FillStroke(f, s),
+                    context_color,
                     text,
                     font_size,
                 );
@@ -446,7 +448,7 @@ impl ContentBuilder {
                     },
                     glyphs,
                     font.clone(),
-                    PaintMode::Fill(f),
+                    context_color,
                     text,
                     font_size,
                 );
@@ -464,7 +466,7 @@ impl ContentBuilder {
                     },
                     glyphs,
                     font.clone(),
-                    PaintMode::Stroke(s),
+                    context_color,
                     text,
                     font_size,
                 );
@@ -487,7 +489,7 @@ impl ContentBuilder {
         font_identifier: FontIdentifier,
         pdf_font: &dyn PdfFont,
         size: f32,
-        paint_mode: PaintMode,
+        context_color: rgb::Color,
         glyphs: &[impl Glyph],
         text: &str,
     ) {
@@ -522,7 +524,7 @@ impl ContentBuilder {
             }
 
             let pdf_glyph = pdf_font
-                .get_gid(CoveredGlyph::new(glyph.glyph_id(), paint_mode))
+                .get_gid(ColoredGlyph::new(glyph.glyph_id(), context_color))
                 .unwrap();
 
             let scale = |val| val * pdf_font.units_per_em();
@@ -579,7 +581,7 @@ impl ContentBuilder {
         action: impl FnOnce(&mut ContentBuilder, &mut SerializeContext),
         glyphs: &[impl Glyph],
         font: Font,
-        paint_mode: PaintMode,
+        context_color: rgb::Color,
         text: &str,
         font_size: f32,
     ) {
@@ -597,8 +599,12 @@ impl ContentBuilder {
                 sb.content.begin_text();
 
                 let font_container = sc.register_font_container(font.clone());
-                let do_text_span =
-                    use_text_spanner(glyphs, text, paint_mode, &mut font_container.borrow_mut());
+                let do_text_span = use_text_spanner(
+                    glyphs,
+                    text,
+                    context_color,
+                    &mut font_container.borrow_mut(),
+                );
 
                 if do_text_span {
                     // Separate into distinct glyph runs that either are encoded using actual text, or are
@@ -609,7 +615,7 @@ impl ContentBuilder {
                         sc.serialize_settings()
                             .validator()
                             .requires_codepoint_mappings(),
-                        paint_mode,
+                        context_color,
                         font_container.clone(),
                     );
 
@@ -621,7 +627,7 @@ impl ContentBuilder {
                             sc,
                             fill_render_mode,
                             font_container.clone(),
-                            paint_mode,
+                            context_color,
                             text,
                             font_size,
                         )
@@ -636,7 +642,7 @@ impl ContentBuilder {
                         sc,
                         fill_render_mode,
                         font_container.clone(),
-                        paint_mode,
+                        context_color,
                         text,
                         font_size,
                     )
@@ -657,7 +663,7 @@ impl ContentBuilder {
         sc: &mut SerializeContext,
         fill_render_mode: TextRenderingMode,
         font_container: Rc<RefCell<FontContainer>>,
-        paint_mode: PaintMode,
+        context_color: rgb::Color,
         text: &str,
         font_size: f32,
     ) {
@@ -670,7 +676,7 @@ impl ContentBuilder {
 
         // Segment into glyph runs that can be encoded in one go using a PDF
         // text showing operator (i.e. no y shift, same Type3 font, etc.)
-        let segmented = GlyphGrouper::new(font_container.clone(), paint_mode, fragment.glyphs());
+        let segmented = GlyphGrouper::new(font_container.clone(), context_color, fragment.glyphs());
 
         for glyph_group in segmented {
             self.fill_stroke_glyph_group(
@@ -680,7 +686,7 @@ impl ContentBuilder {
                 sc,
                 fill_render_mode,
                 font_container.clone(),
-                paint_mode,
+                context_color,
                 text,
                 font_size,
             )
@@ -700,7 +706,7 @@ impl ContentBuilder {
         sc: &mut SerializeContext,
         fill_render_mode: TextRenderingMode,
         font_container: Rc<RefCell<FontContainer>>,
-        paint_mode: PaintMode,
+        context_color: rgb::Color,
         text: &str,
         font_size: f32,
     ) {
@@ -727,7 +733,7 @@ impl ContentBuilder {
             glyph_group.font_identifier,
             pdf_font,
             font_size,
-            paint_mode,
+            context_color,
             glyph_group.glyphs,
             text,
         );

--- a/crates/krilla/src/content.rs
+++ b/crates/krilla/src/content.rs
@@ -35,7 +35,7 @@ use crate::serialize::{MaybeDeviceColorSpace, SerializeContext};
 use crate::stream::Stream;
 use crate::text::group::{use_text_spanner, GlyphGroup, GlyphGrouper, GlyphSpan, GlyphSpanner};
 use crate::text::type3::ColoredGlyph;
-use crate::text::{Font, FontContainer, FontIdentifier, PaintMode, PdfFont, PDF_UNITS_PER_EM};
+use crate::text::{Font, FontContainer, FontIdentifier, PdfFont, PDF_UNITS_PER_EM};
 use crate::text::{Glyph, GlyphId};
 use crate::util::{calculate_stroke_bbox, NameExt};
 

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -24,10 +24,10 @@ use crate::paint::{InnerPaint, Paint};
 use crate::serialize::SerializeContext;
 use crate::stream::{Stream, StreamBuilder};
 use crate::tagging::SpanTag;
+use crate::text::Font;
 use crate::text::{draw_glyph, Glyph};
 #[cfg(feature = "simple-text")]
 use crate::text::{shape::naive_shape, TextDirection};
-use crate::text::{Font, PaintMode};
 
 /// Can be used to associate render operations with a unique identifier.
 /// This is useful if you want to backtrack a validation error to a specific

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -4,6 +4,7 @@
 //! represents a drawing area on which you can define the contents of your page. This includes
 //! operations such as applying linear transformations, showing text or images and drawing paths.
 
+use crate::color::rgb;
 use crate::content::ContentBuilder;
 use crate::geom::Path;
 #[cfg(feature = "raster-images")]
@@ -217,7 +218,7 @@ impl<'a> Surface<'a> {
     fn outline_glyphs(
         &mut self,
         glyphs: &[impl Glyph],
-        paint_mode: PaintMode,
+        context_color: rgb::Color,
         start: Point,
         font: Font,
         font_size: f32,
@@ -235,7 +236,7 @@ impl<'a> Surface<'a> {
             ));
             draw_glyph(
                 font.clone(),
-                paint_mode,
+                context_color,
                 glyph.glyph_id(),
                 Transform::from_tsp(base_transform),
                 self,
@@ -259,25 +260,9 @@ impl<'a> Surface<'a> {
         font_size: f32,
         outlined: bool,
     ) {
+        let context_color = self.context_color();
         if outlined {
-            if let Some(paint_mode) = self.paint_mode() {
-                self.outline_glyphs(
-                    glyphs,
-                    paint_mode.to_owned().as_ref(),
-                    start,
-                    font,
-                    font_size,
-                );
-            } else {
-                // Draw with black by default.
-                self.outline_glyphs(
-                    glyphs,
-                    PaintMode::Fill(&Fill::default()),
-                    start,
-                    font,
-                    font_size,
-                );
-            }
+            self.outline_glyphs(glyphs, context_color, start, font, font_size);
         } else {
             match (self.fill.as_ref(), self.stroke.as_ref()) {
                 (Some(f), Some(s)) => {
@@ -289,26 +274,21 @@ impl<'a> Surface<'a> {
                             self.sc,
                             Some(f),
                             None,
+                            context_color,
                             glyphs,
                             font.clone(),
                             text,
                             font_size,
                         );
 
-                        let stroke = s.clone();
-                        self.outline_glyphs(
-                            glyphs,
-                            PaintMode::Stroke(&stroke),
-                            start,
-                            font,
-                            font_size,
-                        );
+                        self.outline_glyphs(glyphs, context_color, start, font, font_size);
                     } else {
                         self.bd.get_mut().draw_glyphs(
                             start,
                             self.sc,
                             Some(f),
                             Some(s),
+                            context_color,
                             glyphs,
                             font,
                             text,
@@ -322,6 +302,7 @@ impl<'a> Surface<'a> {
                         self.sc,
                         None,
                         Some(s),
+                        context_color,
                         glyphs,
                         font,
                         text,
@@ -334,6 +315,7 @@ impl<'a> Surface<'a> {
                         self.sc,
                         Some(f),
                         None,
+                        context_color,
                         glyphs,
                         font,
                         text,
@@ -347,6 +329,7 @@ impl<'a> Surface<'a> {
                         self.sc,
                         Some(&Fill::default()),
                         None,
+                        context_color,
                         glyphs,
                         font,
                         text,
@@ -514,12 +497,13 @@ impl<'a> Surface<'a> {
         self.bd.get().cur_transform()
     }
 
-    fn paint_mode(&self) -> Option<PaintMode> {
-        match (&self.fill, &self.stroke) {
-            (None, None) => None,
-            (Some(f), None) => Some(PaintMode::Fill(f)),
-            (None, Some(s)) => Some(PaintMode::Stroke(s)),
-            (Some(f), Some(s)) => Some(PaintMode::FillStroke(f, s)),
+    fn context_color(&self) -> rgb::Color {
+        if let Some(c) = self.fill.as_ref().and_then(|f| f.paint.as_rgb()) {
+            c
+        } else if let Some(c) = self.stroke.as_ref().and_then(|s| s.paint.as_rgb()) {
+            c
+        } else {
+            rgb::Color::black()
         }
     }
 

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -498,13 +498,11 @@ impl<'a> Surface<'a> {
     }
 
     fn context_color(&self) -> rgb::Color {
-        if let Some(c) = self.fill.as_ref().and_then(|f| f.paint.as_rgb()) {
-            c
-        } else if let Some(c) = self.stroke.as_ref().and_then(|s| s.paint.as_rgb()) {
-            c
-        } else {
-            rgb::Color::black()
-        }
+        self.fill
+            .as_ref()
+            .and_then(|f| f.paint.as_rgb())
+            .or_else(|| self.stroke.as_ref().and_then(|s| s.paint.as_rgb()))
+            .unwrap_or(rgb::Color::black())
     }
 
     fn has_complex_fill_or_stroke(&self) -> bool {

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -502,7 +502,7 @@ impl<'a> Surface<'a> {
             .as_ref()
             .and_then(|f| f.paint.as_rgb())
             .or_else(|| self.stroke.as_ref().and_then(|s| s.paint.as_rgb()))
-            .unwrap_or(rgb::Color::black())
+            .unwrap_or_default()
     }
 
     fn has_complex_fill_or_stroke(&self) -> bool {

--- a/crates/krilla/src/text/font.rs
+++ b/crates/krilla/src/text/font.rs
@@ -167,6 +167,7 @@ pub(crate) struct FontInfo {
     weight: FiniteF32,
     has_glyf: bool,
     has_cff: bool,
+    has_cff2: bool,
     stretch: FiniteF32,
 }
 
@@ -231,6 +232,7 @@ impl FontInfo {
 
         let has_glyf = font_ref.glyf().is_ok();
         let has_cff = font_ref.cff().is_ok();
+        let has_cff2 = font_ref.cff2().is_ok();
 
         Some(FontInfo {
             index,
@@ -243,6 +245,7 @@ impl FontInfo {
             cap_height,
             has_glyf,
             has_cff,
+            has_cff2,
             descent,
             is_monospaced,
             weight,
@@ -253,7 +256,7 @@ impl FontInfo {
     }
 
     pub(crate) fn can_be_cid_font(&self) -> bool {
-        self.has_cff || self.has_glyf
+        self.has_cff || self.has_glyf || self.has_cff2
     }
 }
 

--- a/crates/krilla/src/text/glyph/colr.rs
+++ b/crates/krilla/src/text/glyph/colr.rs
@@ -15,8 +15,8 @@ use crate::graphics::paint::{
 use crate::num::NormalizedF32;
 use crate::surface::Surface;
 use crate::text::outline::OutlineBuilder;
+use crate::text::Font;
 use crate::text::GlyphId;
-use crate::text::{Font, PaintMode};
 
 pub(crate) fn has_colr_data(font: &Font, glyph: GlyphId) -> bool {
     font.font_ref()

--- a/crates/krilla/src/text/glyph/colr.rs
+++ b/crates/krilla/src/text/glyph/colr.rs
@@ -28,7 +28,7 @@ pub(crate) fn has_colr_data(font: &Font, glyph: GlyphId) -> bool {
 /// Draw a COLR-based glyph on a surface.
 pub(crate) fn draw_glyph(
     font: Font,
-    paint_mode: PaintMode,
+    context_color: rgb::Color,
     glyph: GlyphId,
     surface: &mut Surface,
 ) -> Option<()> {
@@ -37,13 +37,6 @@ pub(crate) fn draw_glyph(
     // we already drew the instructions onto the surface. Because of this, we first
     // convert the glyph into a more accessible bytecode representation and only
     // if that succeeds do we iterate over the bytecode to draw onto the canvas.
-
-    let context_color = match paint_mode {
-        PaintMode::Fill(f) => f.paint.as_rgb(),
-        PaintMode::Stroke(s) => s.paint.as_rgb(),
-        PaintMode::FillStroke(f, _) => f.paint.as_rgb(),
-    }
-    .unwrap_or_default();
 
     let colr_glyphs = font.font_ref().color_glyphs();
     let colr_glyph = colr_glyphs.get(glyph.to_skrifa())?;

--- a/crates/krilla/src/text/glyph/mod.rs
+++ b/crates/krilla/src/text/glyph/mod.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use crate::color::rgb;
 use crate::geom::Transform;
 use crate::surface::Surface;
-use crate::text::{Font, PaintMode};
+use crate::text::Font;
 
 #[cfg(feature = "raster-images")]
 pub(crate) mod bitmap;

--- a/crates/krilla/src/text/glyph/mod.rs
+++ b/crates/krilla/src/text/glyph/mod.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use crate::color::rgb;
 use crate::geom::Transform;
 use crate::surface::Surface;
 use crate::text::{Font, PaintMode};
@@ -33,7 +34,7 @@ impl GlyphId {
 /// Draw a color glyph to a surface.
 pub(crate) fn draw_color_glyph(
     font: Font,
-    paint_mode: PaintMode,
+    context_color: rgb::Color,
     glyph: GlyphId,
     base_transform: Transform,
     surface: &mut Surface,
@@ -41,8 +42,8 @@ pub(crate) fn draw_color_glyph(
     surface.push_transform(&base_transform);
     surface.push_transform(&Transform::from_scale(1.0, -1.0));
 
-    let drawn = colr::draw_glyph(font.clone(), paint_mode, glyph, surface)
-        .or_else(|| svg::draw_glyph(font.clone(), paint_mode, glyph, surface))
+    let drawn = colr::draw_glyph(font.clone(), context_color, glyph, surface)
+        .or_else(|| svg::draw_glyph(font.clone(), context_color, glyph, surface))
         .or_else(|| {
             #[cfg(feature = "raster-images")]
             let res = bitmap::draw_glyph(font.clone(), glyph, surface);
@@ -72,12 +73,12 @@ pub(crate) fn should_outline(font: &Font, glyph: GlyphId) -> bool {
 /// Draw a color glyph or outline glyph to a surface.
 pub(crate) fn draw_glyph(
     font: Font,
-    paint_mode: PaintMode,
+    context_color: rgb::Color,
     glyph: GlyphId,
     base_transform: Transform,
     surface: &mut Surface,
 ) -> Option<()> {
-    draw_color_glyph(font.clone(), paint_mode, glyph, base_transform, surface)
+    draw_color_glyph(font.clone(), context_color, glyph, base_transform, surface)
         .or_else(|| outline::draw_glyph(font, glyph, base_transform, surface))
 }
 

--- a/crates/krilla/src/text/glyph/svg.rs
+++ b/crates/krilla/src/text/glyph/svg.rs
@@ -2,8 +2,8 @@ use skrifa::raw::TableProvider;
 
 use crate::color::rgb;
 use crate::surface::Surface;
+use crate::text::Font;
 use crate::text::GlyphId;
-use crate::text::{Font, PaintMode};
 
 pub(crate) fn has_svg_data(font: &Font, glyph: GlyphId) -> bool {
     font.font_ref()

--- a/crates/krilla/src/text/glyph/svg.rs
+++ b/crates/krilla/src/text/glyph/svg.rs
@@ -1,5 +1,6 @@
 use skrifa::raw::TableProvider;
 
+use crate::color::rgb;
 use crate::surface::Surface;
 use crate::text::GlyphId;
 use crate::text::{Font, PaintMode};
@@ -14,7 +15,7 @@ pub(crate) fn has_svg_data(font: &Font, glyph: GlyphId) -> bool {
 /// Draw an SVG-based glyph on a surface.
 pub(crate) fn draw_glyph(
     font: Font,
-    paint_mode: PaintMode,
+    context_color: rgb::Color,
     glyph: GlyphId,
     surface: &mut Surface,
 ) -> Option<()> {
@@ -23,13 +24,6 @@ pub(crate) fn draw_glyph(
         .svg()
         .and_then(|svg_table| svg_table.glyph_data(glyph.to_skrifa()))
         .ok()??;
-
-    let context_color = match paint_mode {
-        PaintMode::Fill(f) => f.paint.as_rgb(),
-        PaintMode::Stroke(s) => s.paint.as_rgb(),
-        PaintMode::FillStroke(f, _) => f.paint.as_rgb(),
-    }
-    .unwrap_or_default();
 
     let fn_ = surface.sc.serialize_settings().render_svg_glyph_fn;
     fn_(svg_data, context_color, glyph, surface)?;

--- a/crates/krilla/src/text/group.rs
+++ b/crates/krilla/src/text/group.rs
@@ -2,7 +2,8 @@ use std::cell::{RefCell, RefMut};
 use std::ops::Range;
 use std::rc::Rc;
 
-use crate::text::type3::CoveredGlyph;
+use crate::color::rgb;
+use crate::text::type3::ColoredGlyph;
 use crate::text::Glyph;
 use crate::text::{FontContainer, FontIdentifier, PaintMode};
 
@@ -55,7 +56,7 @@ where
     T: Glyph,
 {
     slice: &'a [T],
-    paint_mode: PaintMode<'a>,
+    context_color: rgb::Color,
     forbid_invalid_codepoints: bool,
     font_container: Rc<RefCell<FontContainer>>,
     text: &'a str,
@@ -69,12 +70,12 @@ where
         slice: &'a [T],
         text: &'a str,
         forbid_invalid_codepoints: bool,
-        paint_mode: PaintMode<'a>,
+        context_color: rgb::Color,
         font_container: Rc<RefCell<FontContainer>>,
     ) -> Self {
         Self {
             slice,
-            paint_mode,
+            context_color,
             forbid_invalid_codepoints,
             text,
             font_container,
@@ -92,7 +93,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         fn func<U>(
             g: &U,
-            paint_mode: PaintMode,
+            context_color: rgb::Color,
             previous_range: Option<Range<usize>>,
             forbid_invalid_codepoints: bool,
             mut font_container: RefMut<FontContainer>,
@@ -102,7 +103,7 @@ where
             U: Glyph,
         {
             let (identifier, pdf_glyph) =
-                font_container.add_glyph(CoveredGlyph::new(g.glyph_id(), paint_mode));
+                font_container.add_glyph(ColoredGlyph::new(g.glyph_id(), context_color));
             let pdf_font = font_container
                 .get_from_identifier_mut(identifier.clone())
                 .unwrap();
@@ -147,7 +148,7 @@ where
         // incompatible.
         let (first_range, first_incompatible) = func(
             iter.next()?,
-            self.paint_mode,
+            self.context_color,
             None,
             self.forbid_invalid_codepoints,
             self.font_container.borrow_mut(),
@@ -159,7 +160,7 @@ where
         for next in iter {
             let (next_range, next_incompatible) = func(
                 next,
-                self.paint_mode,
+                self.context_color,
                 Some(prev_range.clone()),
                 self.forbid_invalid_codepoints,
                 self.font_container.borrow_mut(),
@@ -280,7 +281,7 @@ where
     T: Glyph,
 {
     font_container: Rc<RefCell<FontContainer>>,
-    paint_mode: PaintMode<'a>,
+    context_color: rgb::Color,
     slice: &'a [T],
 }
 
@@ -290,12 +291,12 @@ where
 {
     pub fn new(
         font_container: Rc<RefCell<FontContainer>>,
-        paint_mode: PaintMode<'a>,
+        context_color: rgb::Color,
         slice: &'a [T],
     ) -> Self {
         Self {
             font_container,
-            paint_mode,
+            context_color,
             slice,
         }
     }
@@ -317,13 +318,16 @@ where
             let mut iter = self.slice.iter();
             let first = get_glyph_props(
                 iter.next()?,
-                self.paint_mode,
+                self.context_color,
                 &mut self.font_container.borrow_mut(),
             );
 
             for next in iter {
-                let temp_glyph =
-                    get_glyph_props(next, self.paint_mode, &mut self.font_container.borrow_mut());
+                let temp_glyph = get_glyph_props(
+                    next,
+                    self.context_color,
+                    &mut self.font_container.borrow_mut(),
+                );
 
                 // If either of those is different, we need to start a new subrun.
                 if first.font_identifier != temp_glyph.font_identifier
@@ -357,7 +361,7 @@ pub(crate) struct GlyphProps {
 
 pub(crate) fn get_glyph_props<U>(
     g: &U,
-    paint_mode: PaintMode,
+    context_color: rgb::Color,
     font_container: &mut FontContainer,
 ) -> GlyphProps
 where
@@ -365,7 +369,7 @@ where
 {
     // Safe because we've already added all glyphs in the text spanner.
     let font_identifier = font_container
-        .font_identifier(CoveredGlyph::new(g.glyph_id(), paint_mode))
+        .font_identifier(ColoredGlyph::new(g.glyph_id(), context_color))
         .unwrap();
 
     GlyphProps {
@@ -378,7 +382,7 @@ where
 pub fn use_text_spanner(
     glyphs: &[impl Glyph],
     text: &str,
-    paint_mode: PaintMode,
+    context_color: rgb::Color,
     font_container: &mut FontContainer,
 ) -> bool {
     if glyphs.is_empty() {
@@ -399,7 +403,7 @@ pub fn use_text_spanner(
         // The only reason we keep going and don't early abort is in order to fully
         // check the `do_glyph_grouping` property.
         if !*do_text_span {
-            check_text_span_prop(glyph, text, paint_mode, font_container, do_text_span);
+            check_text_span_prop(glyph, text, context_color, font_container, do_text_span);
         }
     };
 
@@ -422,12 +426,12 @@ pub fn use_text_spanner(
 fn check_text_span_prop(
     glyph: &impl Glyph,
     text: &str,
-    paint_mode: PaintMode,
+    context_color: rgb::Color,
     font_container: &mut FontContainer,
     do_text_span: &mut bool,
 ) {
     let (identifier, pdf_glyph) =
-        font_container.add_glyph(CoveredGlyph::new(glyph.glyph_id(), paint_mode));
+        font_container.add_glyph(ColoredGlyph::new(glyph.glyph_id(), context_color));
     let pdf_font = font_container
         .get_from_identifier_mut(identifier.clone())
         .unwrap();

--- a/crates/krilla/src/text/group.rs
+++ b/crates/krilla/src/text/group.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use crate::color::rgb;
 use crate::text::type3::ColoredGlyph;
 use crate::text::Glyph;
-use crate::text::{FontContainer, FontIdentifier, PaintMode};
+use crate::text::{FontContainer, FontIdentifier};
 
 pub(crate) enum GlyphSpan<'a, T>
 where

--- a/crates/krilla/src/text/mod.rs
+++ b/crates/krilla/src/text/mod.rs
@@ -34,25 +34,6 @@ pub use shape::TextDirection;
 
 pub(crate) const PDF_UNITS_PER_EM: f32 = 1000.0;
 
-impl PaintMode<'_> {
-    pub(crate) fn to_owned(self) -> OwnedPaintMode {
-        match self {
-            PaintMode::Fill(f) => OwnedPaintMode::Fill((*f).clone()),
-            PaintMode::Stroke(s) => OwnedPaintMode::Stroke((*s).clone()),
-            PaintMode::FillStroke(f, s) => OwnedPaintMode::FillStroke((*f).clone(), (*s).clone()),
-        }
-    }
-}
-
-/// A wrapper enum for fills/strokes. We use that to keep track whether a Type3 font contains
-/// filled or stroked outlines of a glyph.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum PaintMode<'a> {
-    Fill(&'a Fill),
-    Stroke(&'a Stroke),
-    FillStroke(&'a Fill, &'a Stroke),
-}
-
 /// A unique CID identifier.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub(crate) struct CIDIdentifier(pub Font);
@@ -76,7 +57,6 @@ pub(crate) enum FontIdentifier {
 pub(crate) enum OwnedPaintMode {
     Fill(Fill),
     Stroke(Stroke),
-    FillStroke(Fill, Stroke),
 }
 
 impl From<Fill> for OwnedPaintMode {

--- a/crates/krilla/src/text/mod.rs
+++ b/crates/krilla/src/text/mod.rs
@@ -16,7 +16,6 @@ use std::hash::Hash;
 
 use fxhash::FxHashMap;
 
-use crate::graphics::paint::{Fill, Stroke};
 use crate::text::cid::CIDFont;
 use crate::text::type3::{ColoredGlyph, Type3Font, Type3FontMapper, Type3ID};
 pub(crate) mod cid;
@@ -50,25 +49,6 @@ pub(crate) struct Type3Identifier(pub Font, pub Type3ID);
 pub(crate) enum FontIdentifier {
     Cid(CIDIdentifier),
     Type3(Type3Identifier),
-}
-
-/// The owned version of `PaintMode`.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub(crate) enum OwnedPaintMode {
-    Fill(Fill),
-    Stroke(Stroke),
-}
-
-impl From<Fill> for OwnedPaintMode {
-    fn from(value: Fill) -> Self {
-        Self::Fill(value)
-    }
-}
-
-impl From<Stroke> for OwnedPaintMode {
-    fn from(value: Stroke) -> Self {
-        Self::Stroke(value)
-    }
 }
 
 /// A container that holds all PDF fonts belonging to an OTF font.

--- a/crates/krilla/src/text/type3.rs
+++ b/crates/krilla/src/text/type3.rs
@@ -475,8 +475,8 @@ pub(crate) fn base_font_name(font: &Font) -> String {
 mod tests {
     use crate::color::rgb;
     use crate::text::type3::{ColoredGlyph, Type3FontMapper};
-    use crate::text::GlyphId;
     use crate::text::Font;
+    use crate::text::GlyphId;
     use crate::util::test_utils::NOTO_COLOR_EMOJI_COLR;
 
     #[test]

--- a/crates/krilla/src/text/type3.rs
+++ b/crates/krilla/src/text/type3.rs
@@ -7,7 +7,7 @@ use pdf_writer::types::{FontFlags, UnicodeCmap};
 use pdf_writer::writers::WMode;
 use pdf_writer::{Chunk, Content, Finish, Name, Ref, Str};
 
-use super::{FontIdentifier, OwnedPaintMode, PaintMode, Type3Identifier};
+use super::{FontIdentifier, Type3Identifier};
 use crate::color::rgb;
 use crate::configure::PdfVersion;
 use crate::geom::Path;
@@ -474,10 +474,9 @@ pub(crate) fn base_font_name(font: &Font) -> String {
 #[cfg(test)]
 mod tests {
     use crate::color::rgb;
-    use crate::graphics::paint::Fill;
     use crate::text::type3::{ColoredGlyph, Type3FontMapper};
     use crate::text::GlyphId;
-    use crate::text::{Font, OwnedPaintMode};
+    use crate::text::Font;
     use crate::util::test_utils::NOTO_COLOR_EMOJI_COLR;
 
     #[test]

--- a/crates/krilla/src/text/type3.rs
+++ b/crates/krilla/src/text/type3.rs
@@ -99,8 +99,8 @@ impl Type3Font {
         } else {
             assert!(self.glyphs.len() < 256);
 
-            self.glyph_set.insert(glyph.clone());
-            self.glyphs.push(glyph.clone());
+            self.glyph_set.insert(glyph);
+            self.glyphs.push(glyph);
             self.widths
                 .push(self.font.advance_width(glyph.glyph_id).unwrap_or(0.0));
             u8::try_from(self.glyphs.len() - 1).unwrap()


### PR DESCRIPTION
We should implement them as shape glyphs instead in the future, even though they don't have great support in PDF viewers.