### PR TITLE
Add PageLayout to Metadata

### DIFF
--- a/crates/krilla-tests/src/metadata.rs
+++ b/crates/krilla-tests/src/metadata.rs
@@ -1,4 +1,4 @@
-use krilla::metadata::{DateTime, Metadata, TextDirection};
+use krilla::metadata::{DateTime, Metadata, PageLayout, TextDirection};
 use krilla::Document;
 use krilla_macros::snapshot;
 
@@ -24,7 +24,8 @@ pub(crate) fn metadata_impl(document: &mut Document) {
         ])
         .title("An awesome title".to_string())
         .authors(vec!["John Doe".to_string(), "Max Mustermann".to_string()])
-        .text_direction(TextDirection::LeftToRight);
+        .text_direction(TextDirection::LeftToRight)
+        .page_layout(PageLayout::TwoColumnRight);
     document.set_metadata(metadata);
 }
 

--- a/crates/krilla/src/chunk_container.rs
+++ b/crates/krilla/src/chunk_container.rs
@@ -6,6 +6,7 @@ use xmp_writer::{RenditionClass, XmpWriter};
 use crate::configure::{PdfVersion, ValidationError};
 use crate::error::KrillaResult;
 use crate::interchange::metadata::Metadata;
+use crate::metadata::PageLayout;
 use crate::serialize::SerializeContext;
 use crate::util::{hash_base64, Deferred};
 
@@ -222,7 +223,12 @@ impl ChunkContainer {
 
             let page_layout = self.metadata.as_ref().and_then(|m| m.page_layout);
             if let Some(layout) = page_layout {
-                catalog.page_layout(layout.to_pdf());
+                // TwoPageLeft and TwoPageRight are only available PDF 1.5+
+                if sc.serialize_settings().pdf_version() >= PdfVersion::Pdf15
+                    || !matches!(layout, PageLayout::TwoPageLeft | PageLayout::TwoPageRight)
+                {
+                    catalog.page_layout(layout.to_pdf());
+                }
             }
 
             if let Some(ol) = &self.outline {

--- a/crates/krilla/src/chunk_container.rs
+++ b/crates/krilla/src/chunk_container.rs
@@ -206,7 +206,7 @@ impl ChunkContainer {
                 .serialize_settings()
                 .validator()
                 .requires_display_doc_title();
-            let text_direction = self.metadata.and_then(|m| m.text_direction);
+            let text_direction = self.metadata.as_ref().and_then(|m| m.text_direction);
 
             if write_doc_title || text_direction.is_some() {
                 let mut vp = catalog.viewer_preferences();
@@ -218,6 +218,11 @@ impl ChunkContainer {
                 if let Some(dir) = text_direction {
                     vp.direction(dir.to_pdf());
                 }
+            }
+
+            let page_layout = self.metadata.as_ref().and_then(|m| m.page_layout);
+            if let Some(layout) = page_layout {
+                catalog.page_layout(layout.to_pdf());
             }
 
             if let Some(ol) = &self.outline {

--- a/crates/krilla/src/interchange/metadata.rs
+++ b/crates/krilla/src/interchange/metadata.rs
@@ -25,6 +25,7 @@ pub struct Metadata {
     pub(crate) language: Option<String>,
     pub(crate) creation_date: Option<DateTime>,
     pub(crate) text_direction: Option<TextDirection>,
+    pub(crate) page_layout: Option<PageLayout>,
 }
 
 impl Metadata {
@@ -109,6 +110,12 @@ impl Metadata {
     /// The main text direction of the document.
     pub fn text_direction(mut self, text_direction: TextDirection) -> Self {
         self.text_direction = Some(text_direction);
+        self
+    }
+
+    /// How the viewer should lay out the pages.
+    pub fn page_layout(mut self, page_layout: PageLayout) -> Self {
+        self.page_layout = Some(page_layout);
         self
     }
 
@@ -417,6 +424,40 @@ impl TextDirection {
         match self {
             TextDirection::LeftToRight => pdf_writer::types::Direction::L2R,
             TextDirection::RightToLeft => pdf_writer::types::Direction::R2L,
+        }
+    }
+}
+
+/// How the viewer should lay out the pages.
+#[derive(Copy, Clone, Debug)]
+pub enum PageLayout {
+    /// Only a single page at a time.
+    SinglePage,
+    /// A single, continuously scrolling column of pages.
+    OneColumn,
+    /// Two continuously scrolling columns of pages, laid out with odd-numbered
+    /// pages on the left.
+    TwoColumnLeft,
+    /// Two continuously scrolling columns of pages, laid out with odd-numbered
+    /// pages on the right (like in a left-bound book).
+    TwoColumnRight,
+    /// Only two pages are visible at a time, laid out with odd-numbered pages
+    /// on the left. PDF 1.5+.
+    TwoPageLeft,
+    /// Only two pages are visible at a time, laid out with odd-numbered pages
+    /// on the right (like in a left-bound book). PDF 1.5+.
+    TwoPageRight,
+}
+
+impl PageLayout {
+    pub(crate) fn to_pdf(self) -> pdf_writer::types::PageLayout {
+        match self {
+            PageLayout::SinglePage => pdf_writer::types::PageLayout::SinglePage,
+            PageLayout::OneColumn => pdf_writer::types::PageLayout::OneColumn,
+            PageLayout::TwoColumnLeft => pdf_writer::types::PageLayout::TwoColumnLeft,
+            PageLayout::TwoColumnRight => pdf_writer::types::PageLayout::TwoColumnRight,
+            PageLayout::TwoPageLeft => pdf_writer::types::PageLayout::TwoPageLeft,
+            PageLayout::TwoPageRight => pdf_writer::types::PageLayout::TwoPageRight,
         }
     }
 }

--- a/refs/snapshots/metadata_full.txt
+++ b/refs/snapshots/metadata_full.txt
@@ -51,6 +51,7 @@ endobj
   /ViewerPreferences <<
     /Direction /L2R
   >>
+  /PageLayout /TwoColumnRight
 >>
 endobj
 
@@ -70,5 +71,5 @@ trailer
   /ID [(CGF89dB/kZ8HG+0AeiObmg==) (j4s7vQi5tH1RUV+BhUAvDQ==)]
 >>
 startxref
-695
+725
 %%EOF

--- a/refs/snapshots/metadata_full_with_xmp.txt
+++ b/refs/snapshots/metadata_full_with_xmp.txt
@@ -63,6 +63,7 @@ endobj
   /ViewerPreferences <<
     /Direction /L2R
   >>
+  /PageLayout /TwoColumnRight
 >>
 endobj
 
@@ -83,5 +84,5 @@ trailer
   /ID [(CGF89dB/kZ8HG+0AeiObmg==) (j4s7vQi5tH1RUV+BhUAvDQ==)]
 >>
 startxref
-2150
+2180
 %%EOF

--- a/refs/snapshots/pdf_14.txt
+++ b/refs/snapshots/pdf_14.txt
@@ -63,6 +63,7 @@ endobj
   /ViewerPreferences <<
     /Direction /L2R
   >>
+  /PageLayout /TwoColumnRight
 >>
 endobj
 
@@ -83,5 +84,5 @@ trailer
   /ID [(n8mlnPR1ns3UbKG+gfCU9w==) (etvH18cs7C8JeMqYbb552Q==)]
 >>
 startxref
-2150
+2180
 %%EOF

--- a/refs/snapshots/pdf_20.txt
+++ b/refs/snapshots/pdf_20.txt
@@ -43,6 +43,7 @@ endobj
   /ViewerPreferences <<
     /Direction /L2R
   >>
+  /PageLayout /TwoColumnRight
 >>
 endobj
 
@@ -62,5 +63,5 @@ trailer
   /ID [(F1CF232GUzEL/FGeYRuxqw==) (MwwFglmw0BSz8PWEY/ZfSg==)]
 >>
 startxref
-461
+491
 %%EOF


### PR DESCRIPTION
This MR exposes the /PageLayout property of the Document Catalog through the document metadata and adds it to the metadata_full snapshot tests.

I added copied the struct definition for `PageLayout` from `pdf-writer`, analogously to TextDirection (the other option would be to `pub use` the type from `pdf-writer`)