### PR TITLE
Fix page index shadowing number index in parent tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,21 +136,21 @@ jobs:
           sudo mv ./pdfium-linux-x64/lib/libpdfium.so /usr/lib
           rm -r pdfium-linux-x64.tgz
           rm -r pdfium-linux-x64
-          
+
       - name: Download Arlington model
         run: |
           curl -LO https://software.verapdf.org/dev/arlington/1.29/verapdf-arlington-1.29.9-installer.zip
           unzip verapdf-arlington-1.29.9-installer.zip
           cd verapdf-arlington-1.29.9
           java -jar verapdf-izpack-installer-1.29.9.jar ../.github/arlington.xml
-          
+
       - name: Download verapdf model
         run: |
           curl -LO https://software.verapdf.org/dev/1.29/verapdf-greenfield-1.29.16-installer.zip
           unzip verapdf-greenfield-1.29.16-installer.zip
           cd verapdf-greenfield-1.29.16
           java -jar verapdf-izpack-installer-1.29.16.jar ../.github/verapdf.xml
-          
+
       - name: Get pdfbox
         run: |
           curl -LO https://dlcdn.apache.org/pdfbox/3.0.5/pdfbox-app-3.0.5.jar
@@ -181,15 +181,16 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./diffs
-          
+
       - name: Run Arlington PDF tests
-        # We are excluding one file because of https://github.com/pdf-association/arlington-pdf-model/issues/132     
-        run: find ./store -name "*.pdf" 
-          | grep -v "validate_pdf_a4f_full_example.pdf" 
+        # We are excluding one file because of https://github.com/pdf-association/arlington-pdf-model/issues/132
+        run: find ./store -name "*.pdf"
+          | grep -v "validate_pdf_a4f_full_example.pdf"
+          | grep -v "tagging_simple_with_link.pdf"
           | xargs /tmp/arlington/arlington-pdf-model-checker --format text -r -v --loglevel 0 -e ISO_19005_3
-        
-      - name: Run veraPDF tests  
-        run: find store -name "validate*.pdf" 
+
+      - name: Run veraPDF tests
+        run: find store -name "validate*.pdf"
           | xargs /tmp/verapdf/verapdf --format text -r -v --loglevel 0
 
   checks:

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -668,14 +668,14 @@ impl SerializeContext {
 
                 for (index, struct_parent) in struct_parents.iter().enumerate() {
                     match *struct_parent {
-                        StructParentElement::Page(index, num_mcids) => {
+                        StructParentElement::Page(page_index, num_mcids) => {
                             let mut list_chunk = Chunk::new();
                             let list_ref = self.new_ref();
 
                             let mut refs = list_chunk.indirect(list_ref).array();
 
                             for mcid in 0..num_mcids {
-                                let rci = PageTagIdentifier::new(index, mcid);
+                                let rci = PageTagIdentifier::new(page_index, mcid);
                                 refs.item(parent_tree_map.get(&rci.into()).unwrap_or_else(|| {
                                     panic!(
                                         "page tag identifier {:?} doesn't appear in the tag tree",

--- a/refs/snapshots/tagging_simple_with_link.txt
+++ b/refs/snapshots/tagging_simple_with_link.txt
@@ -19,7 +19,7 @@ endobj
   >>
   /K [4 0 R]
   /ParentTree <<
-    /Nums [0 13 0 R 0 3 0 R]
+    /Nums [0 13 0 R 1 3 0 R]
   >>
   /ParentTreeNextKey 2
 >>
@@ -288,7 +288,7 @@ trailer
 <<
   /Size 17
   /Root 16 0 R
-  /ID [(MqX/E3PdIODFRttS9VsXWw==) (MqX/E3PdIODFRttS9VsXWw==)]
+  /ID [(V3OrUgvj1iaHpga6VV8dNw==) (V3OrUgvj1iaHpga6VV8dNw==)]
 >>
 startxref
 4989


### PR DESCRIPTION
This fixes a bug where the wrong integer was written into the `ParentTree` map.

It's marked as a draft, because I've rebased onto #217, since both of them touch the same snapshot test.