### PR TITLE
Automatically generate slightly expanded bounding box for link annotations with quadpoints

### DIFF
--- a/crates/krilla-tests/src/annotation.rs
+++ b/crates/krilla-tests/src/annotation.rs
@@ -11,7 +11,7 @@ use crate::{LinkAnnotation, Target};
 #[snapshot]
 fn annotation_to_link(page: &mut Page) {
     page.add_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         )
@@ -30,7 +30,7 @@ fn annotation_with_quad_points(page: &mut Page) {
     surface.finish();
 
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_with_quad_points(
             vec![
                 Quadrilateral([
                     Point::from_xy(0.0, 50.0),
@@ -52,7 +52,7 @@ fn annotation_to_invalid_destination() {
     let mut d = Document::new_with(settings_1());
     let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
     page.add_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
             Target::Destination(XyzDestination::new(1, Point::from_xy(100.0, 100.0)).into()),
         )
@@ -67,7 +67,7 @@ fn annotation_to_invalid_destination() {
 fn annotation_to_destination(d: &mut Document) {
     let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
     page.add_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(50.0, 0.0, 100.0, 100.0).unwrap(),
             Target::Destination(XyzDestination::new(1, Point::from_xy(100.0, 100.0)).into()),
         )
@@ -82,7 +82,7 @@ fn annotation_to_destination(d: &mut Document) {
 
     let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
     page.add_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(50.0, 100.0, 100.0, 100.0).unwrap(),
             Target::Destination(XyzDestination::new(0, Point::from_xy(0.0, 0.0)).into()),
         )

--- a/crates/krilla-tests/src/annotation.rs
+++ b/crates/krilla-tests/src/annotation.rs
@@ -1,5 +1,5 @@
 use krilla::destination::XyzDestination;
-use krilla::geom::{Point, Rect};
+use krilla::geom::{Point, Quadrilateral, Rect};
 use krilla::page::{Page, PageSettings};
 use krilla::Document;
 use krilla_macros::snapshot;
@@ -11,9 +11,8 @@ use crate::{LinkAnnotation, Target};
 #[snapshot]
 fn annotation_to_link(page: &mut Page) {
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         )
         .into(),
@@ -32,17 +31,15 @@ fn annotation_with_quad_points(page: &mut Page) {
 
     page.add_annotation(
         LinkAnnotation::new(
-            Rect::from_xywh(0.0, 0.0, 100.0, 100.0).unwrap(),
-            Some(vec![
-                Point::from_xy(0.0, 0.0),
-                Point::from_xy(50.0, 0.0),
-                Point::from_xy(50.0, 50.0),
-                Point::from_xy(0.0, 50.0),
-                Point::from_xy(50.0, 50.0),
-                Point::from_xy(100.0, 50.0),
-                Point::from_xy(100.0, 100.0),
-                Point::from_xy(50.0, 100.0),
-            ]),
+            vec![
+                Quadrilateral([
+                    Point::from_xy(0.0, 50.0),
+                    Point::from_xy(50.0, 50.0),
+                    Point::from_xy(50.0, 0.0),
+                    Point::from_xy(0.0, 0.0),
+                ]),
+                Rect::from_xywh(50.0, 50.0, 50.0, 50.0).unwrap().into(),
+            ],
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         )
         .into(),
@@ -55,9 +52,8 @@ fn annotation_to_invalid_destination() {
     let mut d = Document::new_with(settings_1());
     let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Destination(XyzDestination::new(1, Point::from_xy(100.0, 100.0)).into()),
         )
         .into(),
@@ -71,9 +67,8 @@ fn annotation_to_invalid_destination() {
 fn annotation_to_destination(d: &mut Document) {
     let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(50.0, 0.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Destination(XyzDestination::new(1, Point::from_xy(100.0, 100.0)).into()),
         )
         .into(),
@@ -87,9 +82,8 @@ fn annotation_to_destination(d: &mut Document) {
 
     let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(50.0, 100.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Destination(XyzDestination::new(0, Point::from_xy(0.0, 0.0)).into()),
         )
         .into(),

--- a/crates/krilla-tests/src/destination.rs
+++ b/crates/krilla-tests/src/destination.rs
@@ -19,17 +19,15 @@ fn destination_named(d: &mut Document) {
 
     let mut page = d.start_page();
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(0.0, 0.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Destination(dest1.clone().into()),
         )
         .into(),
     );
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(100.0, 100.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Destination(dest2.clone().into()),
         )
         .into(),
@@ -45,9 +43,8 @@ fn destination_named(d: &mut Document) {
 
     let mut page = d.start_page();
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(0.0, 0.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Destination(dest1.clone().into()),
         )
         .into(),

--- a/crates/krilla-tests/src/destination.rs
+++ b/crates/krilla-tests/src/destination.rs
@@ -19,14 +19,14 @@ fn destination_named(d: &mut Document) {
 
     let mut page = d.start_page();
     page.add_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(0.0, 0.0, 100.0, 100.0).unwrap(),
             Target::Destination(dest1.clone().into()),
         )
         .into(),
     );
     page.add_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(100.0, 100.0, 100.0, 100.0).unwrap(),
             Target::Destination(dest2.clone().into()),
         )
@@ -43,7 +43,7 @@ fn destination_named(d: &mut Document) {
 
     let mut page = d.start_page();
     page.add_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(0.0, 0.0, 100.0, 100.0).unwrap(),
             Target::Destination(dest1.clone().into()),
         )

--- a/crates/krilla-tests/src/main.rs
+++ b/crates/krilla-tests/src/main.rs
@@ -767,9 +767,8 @@ pub fn stops_with_3_luma() -> Vec<Stop> {
 }
 
 pub fn youtube_link(x: f32, y: f32, w: f32, h: f32) -> Annotation {
-    LinkAnnotation::new(
+    LinkAnnotation::new_rect(
         krilla::geom::Rect::from_xywh(x, y, w, h).unwrap(),
-        None,
         Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
     )
     .into()

--- a/crates/krilla-tests/src/main.rs
+++ b/crates/krilla-tests/src/main.rs
@@ -767,7 +767,7 @@ pub fn stops_with_3_luma() -> Vec<Stop> {
 }
 
 pub fn youtube_link(x: f32, y: f32, w: f32, h: f32) -> Annotation {
-    LinkAnnotation::new_rect(
+    LinkAnnotation::new(
         krilla::geom::Rect::from_xywh(x, y, w, h).unwrap(),
         Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
     )

--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -97,9 +97,8 @@ fn tagging_simple_with_link_impl(document: &mut Document) {
     surface.finish();
 
     let link_id = page.add_tagged_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(0.0, 0.0, 100.0, 25.0).unwrap(),
-            None,
             Target::Action(Action::Link(LinkAction::new("www.youtube.com".to_string()))),
         )
         .into(),
@@ -516,9 +515,8 @@ fn tagging_annotation_identifer_appears_twice() {
 
     let mut page = document.start_page();
     let link_id = page.add_tagged_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(0.0, 0.0, 100.0, 25.0).unwrap(),
-            None,
             Target::Action(Action::Link(LinkAction::new("www.youtube.com".to_string()))),
         )
         .into(),

--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -97,7 +97,7 @@ fn tagging_simple_with_link_impl(document: &mut Document) {
     surface.finish();
 
     let link_id = page.add_tagged_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(0.0, 0.0, 100.0, 25.0).unwrap(),
             Target::Action(Action::Link(LinkAction::new("www.youtube.com".to_string()))),
         )
@@ -515,7 +515,7 @@ fn tagging_annotation_identifer_appears_twice() {
 
     let mut page = document.start_page();
     let link_id = page.add_tagged_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(0.0, 0.0, 100.0, 25.0).unwrap(),
             Target::Action(Action::Link(LinkAction::new("www.youtube.com".to_string()))),
         )

--- a/crates/krilla-tests/src/validate.rs
+++ b/crates/krilla-tests/src/validate.rs
@@ -90,7 +90,7 @@ pub fn validate_pdf_a_string_length() {
 #[snapshot(settings_7)]
 fn validate_pdf_a_annotation(page: &mut Page) {
     page.add_annotation(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         )
@@ -473,7 +473,7 @@ fn validate_pdf_ua1_full_example(document: &mut Document) {
     surface.finish();
 
     let annotation = page.add_tagged_annotation(Annotation::new_link(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         ),
@@ -520,7 +520,7 @@ fn validate_pdf_ua1_missing_requirements() {
     surface.finish();
 
     let annot = page.add_tagged_annotation(Annotation::new_link(
-        LinkAnnotation::new_rect(
+        LinkAnnotation::new(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         ),

--- a/crates/krilla-tests/src/validate.rs
+++ b/crates/krilla-tests/src/validate.rs
@@ -90,9 +90,8 @@ pub fn validate_pdf_a_string_length() {
 #[snapshot(settings_7)]
 fn validate_pdf_a_annotation(page: &mut Page) {
     page.add_annotation(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         )
         .into(),
@@ -474,9 +473,8 @@ fn validate_pdf_ua1_full_example(document: &mut Document) {
     surface.finish();
 
     let annotation = page.add_tagged_annotation(Annotation::new_link(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         ),
         Some("A link to youtube".to_string()),
@@ -522,9 +520,8 @@ fn validate_pdf_ua1_missing_requirements() {
     surface.finish();
 
     let annot = page.add_tagged_annotation(Annotation::new_link(
-        LinkAnnotation::new(
+        LinkAnnotation::new_rect(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
-            None,
             Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
         ),
         None,

--- a/crates/krilla/src/geom.rs
+++ b/crates/krilla/src/geom.rs
@@ -134,6 +134,39 @@ impl Rect {
     }
 }
 
+/// A quadrilateral.
+///
+/// The points should be given in the following order:
+/// 1. bottom-left
+/// 2. bottom-right
+/// 3. top-right
+/// 4. top-left
+///
+/// Where the coordinate system is Y-down:
+/// ```md
+///      |
+///      |
+/// -----+---->  X
+///      |
+///      |
+///      v
+///
+///      Y
+/// ```
+#[derive(Clone, Copy, PartialEq)]
+pub struct Quadrilateral(pub [Point; 4]);
+
+impl From<Rect> for Quadrilateral {
+    fn from(r: Rect) -> Self {
+        Self([
+            Point::from_xy(r.left(), r.bottom()),
+            Point::from_xy(r.right(), r.bottom()),
+            Point::from_xy(r.right(), r.top()),
+            Point::from_xy(r.left(), r.top()),
+        ])
+    }
+}
+
 /// An affine transformation matrix.
 ///
 /// Unlike other types, doesn't guarantee to be valid. This is Skia quirk.

--- a/crates/krilla/src/interactive/annotation.rs
+++ b/crates/krilla/src/interactive/annotation.rs
@@ -121,11 +121,23 @@ pub struct LinkAnnotation {
 impl LinkAnnotation {
     /// Create a new link annotation.
     ///
+    /// `rect`: The bounding box of the link annotation that it should cover on the page.
+    /// `target`: The target of the link annotation.
+    pub fn new(rect: Rect, target: Target) -> Self {
+        Self {
+            rect,
+            quad_points: None,
+            target,
+        }
+    }
+
+    /// Create a new link annotation.
+    ///
     /// `target`: The target of the link annotation.
     /// `quad_points`: An array of quadrilaterals that define where the link
     /// annotation should be activated. This is useful if you for example have
     /// a link annotation that is broken to one or multiple lines.
-    pub fn new(quad_points: Vec<Quadrilateral>, target: Target) -> Self {
+    pub fn new_with_quad_points(quad_points: Vec<Quadrilateral>, target: Target) -> Self {
         assert!(!quad_points.is_empty());
 
         let mut min_x = f32::INFINITY;
@@ -155,18 +167,6 @@ impl LinkAnnotation {
         Self {
             rect,
             quad_points: Some(quad_points),
-            target,
-        }
-    }
-
-    /// Create a new link annotation.
-    ///
-    /// `rect`: The bounding box of the link annotation that it should cover on the page.
-    /// `target`: The target of the link annotation.
-    pub fn new_rect(rect: Rect, target: Target) -> Self {
-        Self {
-            rect,
-            quad_points: None,
             target,
         }
     }

--- a/crates/krilla/src/interactive/annotation.rs
+++ b/crates/krilla/src/interactive/annotation.rs
@@ -6,12 +6,14 @@
 //! that are supported are "link annotations", which allow you associate a certain region of
 //! the page with a link.
 
+use core::f32;
+
 use pdf_writer::types::AnnotationFlags;
 use pdf_writer::{Chunk, Finish, Name, Ref, TextStr};
 
 use crate::configure::{PdfVersion, ValidationError};
 use crate::error::KrillaResult;
-use crate::geom::{Point, Rect};
+use crate::geom::{Quadrilateral, Rect};
 use crate::interactive::action::Action;
 use crate::interactive::destination::Destination;
 use crate::page::page_root_transform;
@@ -112,23 +114,59 @@ pub enum Target {
 /// A link annotation.
 pub struct LinkAnnotation {
     pub(crate) rect: Rect,
-    pub(crate) quad_points: Option<Vec<Point>>,
+    pub(crate) quad_points: Option<Vec<Quadrilateral>>,
     pub(crate) target: Target,
 }
 
 impl LinkAnnotation {
     /// Create a new link annotation.
     ///
-    /// `rect`: The bounding box of the link annotation that it should cover on the page.
     /// `target`: The target of the link annotation.
-    /// `quad_points`: An array of 4xn points, where each 4 points define the quadrilateral
-    /// where the link annotation should be activated. This is useful if you for example have
-    /// a link annotation that is broken to one or multiple lines. Note that the points
-    /// have to be within the bounds defined by `rect`!
-    pub fn new(rect: Rect, quad_points: Option<Vec<Point>>, target: Target) -> Self {
+    /// `quad_points`: An array of quadrilaterals that define where the link
+    /// annotation should be activated. This is useful if you for example have
+    /// a link annotation that is broken to one or multiple lines.
+    pub fn new(quad_points: Vec<Quadrilateral>, target: Target) -> Self {
+        assert!(!quad_points.is_empty());
+
+        let mut min_x = f32::INFINITY;
+        let mut min_y = f32::INFINITY;
+        let mut max_x = f32::NEG_INFINITY;
+        let mut max_y = f32::NEG_INFINITY;
+
+        for point in quad_points.iter().flat_map(|q| q.0) {
+            min_x = min_x.min(point.x);
+            min_y = min_y.min(point.y);
+            max_x = max_x.max(point.x);
+            max_y = max_y.max(point.y);
+        }
+
+        // Expand the bounding box by a little. There is a bug in adobe acrobat
+        // that sometimes prevents the quadpoints from being used if the quad
+        // points lie exactly on the bounding rectangle.
+        const EPSILON: f32 = 0.001;
+        let rect = Rect::from_ltrb(
+            min_x - EPSILON,
+            min_y - EPSILON,
+            max_x + EPSILON,
+            max_y + EPSILON,
+        )
+        .unwrap();
+
         Self {
             rect,
-            quad_points,
+            quad_points: Some(quad_points),
+            target,
+        }
+    }
+
+    /// Create a new link annotation.
+    ///
+    /// `rect`: The bounding box of the link annotation that it should cover on the page.
+    /// `target`: The target of the link annotation.
+    pub fn new_rect(rect: Rect, target: Target) -> Self {
+        Self {
+            rect,
+            quad_points: None,
             target,
         }
     }
@@ -150,7 +188,7 @@ impl LinkAnnotation {
 
         if sc.serialize_settings().pdf_version() >= PdfVersion::Pdf16 {
             self.quad_points.as_ref().map(|p| {
-                annotation.quad_points(p.iter().flat_map(|p| {
+                annotation.quad_points(p.iter().flat_map(|q| q.0).flat_map(|p| {
                     let mut p = p.to_tsp();
                     page_root_transform(page_height).to_tsp().map_point(&mut p);
                     [p.x, p.y]

--- a/refs/snapshots/annotation_with_quad_points.txt
+++ b/refs/snapshots/annotation_with_quad_points.txt
@@ -13,9 +13,9 @@ endobj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [0 100 100 200]
+  /Rect [-0.001 99.999 100.001 200.001]
   /Border [0 0 0]
-  /QuadPoints [0 200 50 200 50 150 0 150 50 150 100 150 100 100 50 100]
+  /QuadPoints [0 150 50 150 50 200 0 200 50 100 100 100 100 150 50 150]
   /A <<
     /Type /Action
     /S /URI
@@ -78,15 +78,15 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000080 00000 n
-0000000333 00000 n
-0000000510 00000 n
-0000000697 00000 n
+0000000349 00000 n
+0000000526 00000 n
+0000000713 00000 n
 trailer
 <<
   /Size 6
   /Root 5 0 R
-  /ID [(FT6xScnl5C4JCO6e/pFBsA==) (FT6xScnl5C4JCO6e/pFBsA==)]
+  /ID [(/8P2JytSSxHFd8jLlJSIfQ==) (/8P2JytSSxHFd8jLlJSIfQ==)]
 >>
 startxref
-751
+767
 %%EOF


### PR DESCRIPTION
This adds a new `Quadrilateral` type that documents the order in which points should appear.
Instead of the previous `new` function there are now two different functions to construct a `LinkAnnotation`.
One in which just a `Rect` is provided and the other where a non-empty list of `Quadrilateral`s is passed.
The bounding `rect` is computed automatically for the latter.

The choice of `EPSILON` is a little bit random, so feel free to suggest a different number :)