### PR TITLE
Make `DuplicateTagId` and `UnknownTagId` hard errors

### DIFF
--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -507,6 +507,57 @@ fn tagging_page_identifer_appears_twice() {
 }
 
 #[test]
+fn tagging_id_appears_twice() {
+    let mut document = Document::new();
+    let mut tag_tree = TagTree::new();
+
+    let id = TagId::from(*b"one");
+    let loc_1 = 1;
+    let loc_2 = 2;
+    let group_1 = TagGroup::new(
+        TagKind::P
+            .with_id(Some(id.clone()))
+            .with_location(Some(loc_1)),
+    );
+    let group_2 = TagGroup::new(
+        TagKind::P
+            .with_id(Some(id.clone()))
+            .with_location(Some(loc_2)),
+    );
+
+    tag_tree.push(group_1);
+    tag_tree.push(group_2);
+
+    document.set_tag_tree(tag_tree);
+
+    assert_eq!(
+        document.finish(),
+        Err(KrillaError::DuplicateTagId(id, Some(loc_2)))
+    );
+}
+
+#[test]
+fn tagging_unknown_header_tag_id() {
+    let mut document = Document::new();
+    let mut tag_tree = TagTree::new();
+
+    let id = TagId::from(*b"one");
+    let loc_1 = 1;
+    let group_1 = TagGroup::new(
+        TagKind::TD(TableDataCell::new().with_headers([id.clone()])).with_location(Some(loc_1)),
+    );
+
+    tag_tree.push(group_1);
+
+    document.set_tag_tree(tag_tree);
+
+    assert_eq!(
+        document.finish(),
+        Err(KrillaError::UnknownTagId(id, Some(loc_1)))
+    );
+}
+
+#[test]
 #[should_panic]
 fn tagging_annotation_identifer_appears_twice() {
     let mut document = Document::new();

--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -28,7 +28,6 @@ use xmp_writer::XmpWriter;
 use crate::configure::PdfVersion;
 use crate::interchange::embed::EmbedError;
 use crate::surface::Location;
-use crate::tagging::TagId;
 use crate::text::Font;
 use crate::text::GlyphId;
 
@@ -121,14 +120,6 @@ pub enum ValidationError {
     EmbeddedFile(EmbedError, Option<Location>),
     /// The PDF contains no tagging.
     MissingTagging,
-    /// A duplicate [`Tag::id`] was provided.
-    ///
-    /// [`Tag::id`]: crate::interchange::tagging::Tag::id
-    DuplicateTagId(TagId, Option<Location>),
-    /// A [`TagId`] was not found in the [`TagTree`].
-    ///
-    /// [`TagTree`]: crate::interchange::tagging::TagTree
-    UnknownTagId(TagId, Option<Location>),
 }
 
 /// A validator for exporting PDF documents to a specific subset of PDF.
@@ -324,8 +315,6 @@ impl Validator {
                 },
                 ValidationError::MissingTagging => *self == Validator::A1_A,
                 ValidationError::MissingDocumentDate => true,
-                ValidationError::DuplicateTagId(_, _) => true,
-                ValidationError::UnknownTagId(_, _) => true,
             },
             Validator::A2_A | Validator::A2_B | Validator::A2_U => match validation_error {
                 ValidationError::TooLongString => true,
@@ -363,8 +352,6 @@ impl Validator {
                 },
                 ValidationError::MissingTagging => *self == Validator::A2_A,
                 ValidationError::MissingDocumentDate => true,
-                ValidationError::DuplicateTagId(_, _) => true,
-                ValidationError::UnknownTagId(_, _) => true,
             },
             Validator::A3_A | Validator::A3_B | Validator::A3_U => match validation_error {
                 ValidationError::TooLongString => true,
@@ -397,8 +384,6 @@ impl Validator {
                 },
                 ValidationError::MissingTagging => *self == Validator::A3_A,
                 ValidationError::MissingDocumentDate => true,
-                ValidationError::DuplicateTagId(_, _) => true,
-                ValidationError::UnknownTagId(_, _) => true,
             },
             Validator::A4 | Validator::A4F | Validator::A4E => match validation_error {
                 ValidationError::TooLongString => false,
@@ -437,8 +422,6 @@ impl Validator {
                 // Only recommended, not required.
                 ValidationError::MissingTagging => false,
                 ValidationError::MissingDocumentDate => true,
-                ValidationError::DuplicateTagId(_, _) => true,
-                ValidationError::UnknownTagId(_, _) => true,
             },
             Validator::UA1 => match validation_error {
                 ValidationError::TooLongString => false,
@@ -471,8 +454,6 @@ impl Validator {
                 },
                 ValidationError::MissingTagging => true,
                 ValidationError::MissingDocumentDate => false,
-                ValidationError::DuplicateTagId(_, _) => true,
-                ValidationError::UnknownTagId(_, _) => true,
             },
         }
     }

--- a/crates/krilla/src/error.rs
+++ b/crates/krilla/src/error.rs
@@ -7,6 +7,7 @@ use crate::configure::ValidationError;
 #[cfg(feature = "raster-images")]
 use crate::graphics::image::Image;
 use crate::surface::Location;
+use crate::tagging::TagId;
 use crate::text::Font;
 
 /// A wrapper type for krilla errors.
@@ -22,6 +23,14 @@ pub enum KrillaError {
     ///
     /// [`SerializeSettings`]: crate::SerializeSettings
     Validation(Vec<ValidationError>),
+    /// A duplicate [`Tag::id`] was provided.
+    ///
+    /// [`Tag::id`]: crate::interchange::tagging::Tag::id
+    DuplicateTagId(TagId, Option<Location>),
+    /// A [`TagId`] was not found in the [`TagTree`].
+    ///
+    /// [`TagTree`]: crate::interchange::tagging::TagTree
+    UnknownTagId(TagId, Option<Location>),
     /// An image couldn't be processed properly.
     #[cfg(feature = "raster-images")]
     Image(Image, Option<Location>),

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -639,7 +639,7 @@ impl SerializeContext {
             )?;
             self.chunk_container.struct_elements = struct_elems;
 
-            root.validate(self, &id_tree_map);
+            root.validate(&id_tree_map)?;
 
             let mut chunk = Chunk::new();
             let mut tree = chunk.indirect(struct_tree_root_ref).start::<Dict>();


### PR DESCRIPTION
This promotes the `DuplicateTagId` and `UnknownTagId` validation errors to hard errors and adds a test for each of them.

Closes #225 