### PR TITLE
Allow providing a location for missing alt text validation errors

### DIFF
--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -101,13 +101,13 @@ pub enum ValidationError {
     /// the standard.
     NoDocumentTitle,
     /// A figure or formula is missing an alt text.
-    MissingAltText,
+    MissingAltText(Option<Location>),
     /// A heading is missing a title.
     MissingHeadingTitle,
     /// The document does not contain an outline.
     MissingDocumentOutline,
     /// An annotation is missing an alt text.
-    MissingAnnotationAltText,
+    MissingAnnotationAltText(Option<Location>),
     /// The date of the document is missing.
     // We need this because for some standards we need to add the
     // xmp:History attribute.
@@ -296,10 +296,10 @@ impl Validator {
                 ValidationError::UnicodePrivateArea(_, _, _, _) => false,
                 ValidationError::NoDocumentLanguage => *self == Validator::A1_A,
                 ValidationError::NoDocumentTitle => false,
-                ValidationError::MissingAltText => false,
+                ValidationError::MissingAltText(_) => false,
                 ValidationError::MissingHeadingTitle => false,
                 ValidationError::MissingDocumentOutline => false,
-                ValidationError::MissingAnnotationAltText => false,
+                ValidationError::MissingAnnotationAltText(_) => false,
                 ValidationError::Transparency(_) => true,
                 ValidationError::ImageInterpolation(_) => true,
                 // PDF/A1 doesn't strictly forbid, but it disallows the EF key,
@@ -333,10 +333,10 @@ impl Validator {
                 ValidationError::UnicodePrivateArea(_, _, _, _) => *self == Validator::A2_A,
                 ValidationError::NoDocumentLanguage => *self == Validator::A2_A,
                 ValidationError::NoDocumentTitle => false,
-                ValidationError::MissingAltText => false,
+                ValidationError::MissingAltText(_) => false,
                 ValidationError::MissingHeadingTitle => false,
                 ValidationError::MissingDocumentOutline => false,
-                ValidationError::MissingAnnotationAltText => false,
+                ValidationError::MissingAnnotationAltText(_) => false,
                 ValidationError::Transparency(_) => false,
                 ValidationError::ImageInterpolation(_) => true,
                 // Also not strictly forbidden, but we can't ensure that it is PDF/A2 compliant,
@@ -370,10 +370,10 @@ impl Validator {
                 ValidationError::UnicodePrivateArea(_, _, _, _) => *self == Validator::A3_A,
                 ValidationError::NoDocumentLanguage => *self == Validator::A3_A,
                 ValidationError::NoDocumentTitle => false,
-                ValidationError::MissingAltText => false,
+                ValidationError::MissingAltText(_) => false,
                 ValidationError::MissingHeadingTitle => false,
                 ValidationError::MissingDocumentOutline => false,
-                ValidationError::MissingAnnotationAltText => false,
+                ValidationError::MissingAnnotationAltText(_) => false,
                 ValidationError::Transparency(_) => false,
                 ValidationError::ImageInterpolation(_) => true,
                 ValidationError::EmbeddedFile(er, _) => match er {
@@ -402,10 +402,10 @@ impl Validator {
                 ValidationError::UnicodePrivateArea(_, _, _, _) => true,
                 ValidationError::NoDocumentLanguage => false,
                 ValidationError::NoDocumentTitle => false,
-                ValidationError::MissingAltText => false,
+                ValidationError::MissingAltText(_) => false,
                 ValidationError::MissingHeadingTitle => false,
                 ValidationError::MissingDocumentOutline => false,
-                ValidationError::MissingAnnotationAltText => false,
+                ValidationError::MissingAnnotationAltText(_) => false,
                 ValidationError::Transparency(_) => false,
                 ValidationError::ImageInterpolation(_) => true,
                 ValidationError::EmbeddedFile(e, _) => match e {
@@ -440,10 +440,10 @@ impl Validator {
                 ValidationError::UnicodePrivateArea(_, _, _, _) => false,
                 ValidationError::NoDocumentLanguage => false,
                 ValidationError::NoDocumentTitle => true,
-                ValidationError::MissingAltText => true,
+                ValidationError::MissingAltText(_) => true,
                 ValidationError::MissingHeadingTitle => true,
                 ValidationError::MissingDocumentOutline => true,
-                ValidationError::MissingAnnotationAltText => true,
+                ValidationError::MissingAnnotationAltText(_) => true,
                 ValidationError::Transparency(_) => false,
                 ValidationError::ImageInterpolation(_) => false,
                 ValidationError::EmbeddedFile(er, _) => match er {

--- a/crates/krilla/src/interactive/annotation.rs
+++ b/crates/krilla/src/interactive/annotation.rs
@@ -18,12 +18,14 @@ use crate::interactive::action::Action;
 use crate::interactive::destination::Destination;
 use crate::page::page_root_transform;
 use crate::serialize::SerializeContext;
+use crate::surface::Location;
 
 /// An annotation.
 pub struct Annotation {
     pub(crate) annotation_type: AnnotationType,
     pub(crate) alt: Option<String>,
     pub(crate) struct_parent: Option<i32>,
+    pub(crate) location: Option<Location>,
 }
 
 impl Annotation {
@@ -36,7 +38,14 @@ impl Annotation {
             annotation_type: AnnotationType::Link(annotation),
             alt: alt_text,
             struct_parent: None,
+            location: None,
         }
+    }
+
+    /// Sets the location of the annotation.
+    pub fn with_location(mut self, location: Option<Location>) -> Self {
+        self.location = location;
+        self
     }
 }
 
@@ -46,6 +55,7 @@ impl From<LinkAnnotation> for Annotation {
             annotation_type: AnnotationType::Link(value),
             alt: None,
             struct_parent: None,
+            location: None,
         }
     }
 }
@@ -75,7 +85,7 @@ impl Annotation {
         if let Some(alt_text) = &self.alt {
             annotation.contents(TextStr(alt_text));
         } else {
-            sc.register_validation_error(ValidationError::MissingAnnotationAltText);
+            sc.register_validation_error(ValidationError::MissingAnnotationAltText(self.location));
         }
 
         annotation.finish();

--- a/crates/krilla/src/interchange/tagging.rs
+++ b/crates/krilla/src/interchange/tagging.rs
@@ -880,7 +880,7 @@ impl TagGroup {
         if let Some(alt) = &self.tag.alt_text {
             struct_elem.alt(TextStr(alt));
         } else if self.tag.kind.should_have_alt() {
-            sc.register_validation_error(ValidationError::MissingAltText);
+            sc.register_validation_error(ValidationError::MissingAltText(self.tag.location));
         }
 
         if sc.serialize_settings().pdf_version() >= PdfVersion::Pdf15 {


### PR DESCRIPTION
This allows showing the problematic link, figure, or formula on the typst side of things.