### PR TITLE
Make `Location` a `NonZeroU64`

### DIFF
--- a/crates/krilla-tests/src/main.rs
+++ b/crates/krilla-tests/src/main.rs
@@ -6,6 +6,7 @@
 use std::cmp::max;
 use std::env;
 use std::hash::{Hash, Hasher};
+use std::num::NonZeroU64;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, OnceLock};
@@ -27,7 +28,7 @@ use krilla::paint::{Fill, Stop, Stroke};
 use krilla::pdf::{Pdf, PdfDocument};
 use krilla::stream::Stream;
 use krilla::stream::StreamBuilder;
-use krilla::surface::Surface;
+use krilla::surface::{Location, Surface};
 use krilla::text::Font;
 use krilla::text::{GlyphId, KrillaGlyph};
 use krilla::Data;
@@ -224,9 +225,9 @@ fn dummy_glyph(
 pub fn dummy_text_with_spans() -> (String, Vec<KrillaGlyph>) {
     let text = "Hi.".to_string();
     let glyphs = vec![
-        dummy_glyph(GlyphId::new(10), 0..1, Some(3)),
-        dummy_glyph(GlyphId::new(0), 1..2, Some(4)),
-        dummy_glyph(GlyphId::new(20), 2..3, Some(5)),
+        dummy_glyph(GlyphId::new(10), 0..1, Some(loc(3))),
+        dummy_glyph(GlyphId::new(0), 1..2, Some(loc(4))),
+        dummy_glyph(GlyphId::new(20), 2..3, Some(loc(5))),
     ];
 
     (text, glyphs)
@@ -447,6 +448,10 @@ pub fn check_snapshot(name: &str, actual: &[u8], storable: bool) {
     }
 
     assert_eq!(changeset.distance, 0);
+}
+
+pub const fn loc(l: u64) -> Location {
+    NonZeroU64::new(l).unwrap()
 }
 
 pub fn check_render(

--- a/crates/krilla-tests/src/pdf.rs
+++ b/crates/krilla-tests/src/pdf.rs
@@ -14,7 +14,7 @@ use krilla_svg::{SurfaceExt, SvgSettings};
 use crate::metadata::metadata_impl;
 use crate::svg::sample_svg;
 use crate::text::simple_text_impl;
-use crate::{load_pdf, load_png_image, rect_to_path, red_fill, settings_16, NOTO_SANS};
+use crate::{load_pdf, load_png_image, loc, rect_to_path, red_fill, settings_16, NOTO_SANS};
 
 #[snapshot(document)]
 fn pdf_empty(_: &mut Document) {}
@@ -95,7 +95,7 @@ fn pdf_embedded_out_of_bounds() {
     let mut document = Document::new();
 
     let pdf = load_pdf("resvg_masking_clipPath_mixed_clip_rule.pdf");
-    document.set_location(1);
+    document.set_location(loc(1));
     document.embed_pdf_pages(&pdf, &[1]);
 
     assert_eq!(
@@ -103,7 +103,7 @@ fn pdf_embedded_out_of_bounds() {
         Err(KrillaError::Pdf(
             pdf.clone(),
             PdfError::InvalidPage(1),
-            Some(1)
+            Some(loc(1))
         ))
     )
 }

--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -19,7 +19,7 @@ use krilla::Document;
 use krilla_macros::snapshot;
 use krilla_svg::{SurfaceExt, SvgSettings};
 
-use crate::{green_fill, load_png_image, rect_to_path, red_stroke, NOTO_SANS, SVGS_PATH};
+use crate::{green_fill, load_png_image, loc, rect_to_path, red_stroke, NOTO_SANS, SVGS_PATH};
 
 pub trait SurfaceTaggingExt {
     fn fill_text_(&mut self, y: f32, content: &str);
@@ -613,8 +613,8 @@ fn tagging_id_appears_twice() {
     let mut tag_tree = TagTree::new();
 
     let id = TagId::from(*b"one");
-    let loc_1 = 1;
-    let loc_2 = 2;
+    let loc_1 = loc(1);
+    let loc_2 = loc(2);
     let group_1 = TagGroup::new(Tag::P.with_id(Some(id.clone())).with_location(Some(loc_1)));
     let group_2 = TagGroup::new(Tag::P.with_id(Some(id.clone())).with_location(Some(loc_2)));
 
@@ -635,7 +635,7 @@ fn tagging_unknown_header_tag_id() {
     let mut tag_tree = TagTree::new();
 
     let id = TagId::from(*b"one");
-    let loc_1 = 1;
+    let loc_1 = loc(1);
     let group_1 = TagGroup::new(
         Tag::TD
             .with_headers([id.clone()])

--- a/crates/krilla-tests/src/validate.rs
+++ b/crates/krilla-tests/src/validate.rs
@@ -16,7 +16,7 @@ use krilla_macros::snapshot;
 
 use crate::embed::{embedded_file_impl, file_1};
 use crate::{
-    blue_fill, cmyk_fill, dummy_text_with_spans, green_fill, load_jpg_image, load_png_image,
+    blue_fill, cmyk_fill, dummy_text_with_spans, green_fill, load_jpg_image, load_png_image, loc,
     metadata_1, rect_to_path, red_fill, settings_13, settings_15, settings_19, settings_23,
     settings_24, settings_7, settings_8, settings_9, stops_with_2_solid_1, youtube_link, NOTO_SANS,
 };
@@ -211,7 +211,7 @@ fn validate_pdfa2u_text_with_location() {
     let font = Font::new(font_data, 0).unwrap();
     let (text, glyphs) = dummy_text_with_spans();
 
-    surface.set_location(2);
+    surface.set_location(loc(2));
     surface.set_fill(Some(red_fill(0.1)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 10.0, 10.0));
 
@@ -229,7 +229,7 @@ fn validate_pdfa2u_text_with_location() {
     assert_eq!(
         document.finish(),
         Err(KrillaError::Validation(vec![
-            ValidationError::ContainsNotDefGlyph(font, Some(4), "i".to_string())
+            ValidationError::ContainsNotDefGlyph(font, Some(loc(4)), "i".to_string())
         ]))
     )
 }
@@ -240,22 +240,22 @@ fn validate_pdfa1b_transparency_with_location() {
     let mut page = document.start_page();
     let mut surface = page.surface();
 
-    surface.set_location(2);
+    surface.set_location(loc(2));
     surface.set_fill(Some(red_fill(1.0)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 10.0, 10.0));
-    surface.set_location(3);
+    surface.set_location(loc(3));
     surface.set_fill(Some(green_fill(1.0)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 10.0, 10.0));
-    surface.set_location(4);
+    surface.set_location(loc(4));
     surface.set_fill(Some(green_fill(0.9)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 10.0, 10.0));
-    surface.set_location(5);
+    surface.set_location(loc(5));
     surface.set_fill(Some(green_fill(1.0)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 10.0, 10.0));
-    surface.set_location(6);
+    surface.set_location(loc(6));
     surface.set_fill(Some(blue_fill(0.8)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 10.0, 10.0));
-    surface.set_location(7);
+    surface.set_location(loc(7));
     surface.set_fill(Some(blue_fill(0.9)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 10.0, 10.0));
 
@@ -265,8 +265,8 @@ fn validate_pdfa1b_transparency_with_location() {
     assert_eq!(
         document.finish(),
         Err(KrillaError::Validation(vec![
-            ValidationError::Transparency(Some(4)),
-            ValidationError::Transparency(Some(6)),
+            ValidationError::Transparency(Some(loc(4))),
+            ValidationError::Transparency(Some(loc(6))),
             // Note that we don't have 7 here, even though we should in theory. The reason is
             // that since we cache graphics states, only the first time we serialize it will
             // it trigger the validation error. Not optimal, but changing that would be a pain.
@@ -517,7 +517,7 @@ fn validate_pdf_ua1_missing_requirements() {
 
     surface.finish();
 
-    let annot_loc = 1;
+    let annot_loc = loc(1);
     let annot = page.add_tagged_annotation(
         Annotation::new_link(
             LinkAnnotation::new(
@@ -531,7 +531,7 @@ fn validate_pdf_ua1_missing_requirements() {
 
     page.finish();
 
-    let formula_loc = 2;
+    let formula_loc = loc(2);
     let mut tag_group = TagGroup::new(Tag::Formula(None).with_location(Some(formula_loc)));
     tag_group.push(id1);
     tag_group.push(annot);
@@ -758,7 +758,7 @@ fn validate_deduplicate_errors() {
 
     surface.set_fill(Some(red_fill(0.5)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 20.0, 20.0));
-    surface.set_location(2);
+    surface.set_location(loc(2));
     surface.set_fill(Some(red_fill(0.4)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 20.0, 20.0));
     surface.reset_location();
@@ -771,7 +771,7 @@ fn validate_deduplicate_errors() {
         document.finish(),
         Err(KrillaError::Validation(vec![
             ValidationError::Transparency(None),
-            ValidationError::Transparency(Some(2))
+            ValidationError::Transparency(Some(loc(2)))
         ]))
     );
 }

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -4,6 +4,8 @@
 //! represents a drawing area on which you can define the contents of your page. This includes
 //! operations such as applying linear transformations, showing text or images and drawing paths.
 
+use std::num::NonZeroU64;
+
 use crate::color::rgb;
 use crate::content::ContentBuilder;
 #[cfg(any(feature = "raster-images", feature = "pdf"))]
@@ -34,7 +36,7 @@ use crate::text::{shape::naive_shape, TextDirection};
 /// Can be used to associate render operations with a unique identifier.
 /// This is useful if you want to backtrack a validation error to a specific
 /// identifier chosen by you.
-pub type Location = u64;
+pub type Location = NonZeroU64;
 
 /// A surface.
 ///

--- a/crates/krilla/src/text/cid.rs
+++ b/crates/krilla/src/text/cid.rs
@@ -34,7 +34,7 @@ pub(crate) type Cid = u16;
 /// A shared function for CID fonts and Type3 fonts to write the cmap entries.
 pub(crate) fn write_cmap_entry<G>(
     font: &Font,
-    entry: Option<&(String, Option<u64>)>,
+    entry: Option<&(String, Option<Location>)>,
     sc: &mut SerializeContext,
     cmap: &mut UnicodeCmap<G>,
     g: G,


### PR DESCRIPTION
This reduces the size of several structs where `Location` is stored inside of an `Option`.