### PR TITLE
Bump comemo and subsetter, and switch from fxhash to rustc-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,21 +268,22 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "comemo"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6916408a724339aa77b18214233355f3eb04c42eb895e5f8909215bd8a7a91"
+checksum = "649d7b2d867b569729c03c0f6968db10bc95921182a1f2b2012b1b549492f39d"
 dependencies = [
  "comemo-macros",
- "once_cell",
  "parking_lot",
+ "rustc-hash 2.1.1",
  "siphasher",
+ "slab",
 ]
 
 [[package]]
 name = "comemo-macros"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8936e42f9b4f5bdfaf23700609ac1f11cb03ad4c1ec128a4ee4fd0903e228db"
+checksum = "51c87fc7e85487493ddedae1a3a34b897c77ad8825375b79265a8a162c28d535"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -706,15 +707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "gif"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,7 +879,6 @@ dependencies = [
  "flate2",
  "float-cmp 0.10.0",
  "fontdb",
- "fxhash",
  "gif",
  "hayro-write",
  "image 0.25.2",
@@ -901,6 +892,7 @@ dependencies = [
  "png",
  "pretty_assertions",
  "rayon",
+ "rustc-hash 2.1.1",
  "rustybuzz",
  "siphasher",
  "sitro",
@@ -1648,6 +1640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,11 +1692,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subsetter"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35539e8de3dcce8dd0c01f3575f85db1e5ac1aea1b996d2d09d89f148bc91497"
+checksum = "35725d9d2d056905865f8a36146e45be43691b15fc5d973bd7f79dd438288544"
 dependencies = [
- "fxhash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,10 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 base64 = "0.22.1"
 bumpalo = "3.16.0"
-comemo = "0.4.0"
+comemo = "0.5.0"
 difference = "2.0.0"
 flate2 = {version = "1.1.0", default-features = false, features = ["zlib-rs"]}
 float-cmp = "0.10.0"
-fxhash = "0.2.1"
 fontdb = "0.23.0"
 gif = "0.13.1"
 hayro-write = { git = "https://github.com/LaurenzV/hayro", rev = "e701f95" }
@@ -39,12 +38,13 @@ proc-macro2 = "1.0.86"
 quote = "1.0.37"
 rayon = "1.10.0"
 resvg = "0.45.0"
+rustc-hash = "2.1.1"
 rustybuzz = "0.20.1"
 siphasher = "1.0.1"
 sitro = { git = "https://github.com/LaurenzV/sitro", rev = "fb804b3" }
 skrifa = "0.32.0"
 smallvec = { version = "1.15.1", features = ["union", "const_new", "write"] }
-subsetter = "0.2.1"
+subsetter = "0.2.2"
 syn = { version = "2.0.76", features = ["full", "extra-traits"] }
 tiny-skia = "0.11.4"
 tiny-skia-path = "0.11.4"

--- a/crates/krilla/Cargo.toml
+++ b/crates/krilla/Cargo.toml
@@ -31,7 +31,6 @@ bumpalo = { workspace = true }
 comemo = { workspace = true, optional = true }
 flate2 = { workspace = true }
 float-cmp = { workspace = true }
-fxhash =  { workspace = true }
 gif = { workspace = true, optional = true }
 hayro-write = { workspace = true, optional = true }
 image-webp = { workspace = true, optional = true }
@@ -39,6 +38,7 @@ imagesize = { workspace = true, optional = true }
 once_cell = { workspace = true }
 pdf-writer = { workspace = true }
 rayon = { workspace = true, optional = true }
+rustc-hash =  { workspace = true }
 rustybuzz = { workspace = true, optional = true }
 siphasher = { workspace = true }
 subsetter = { workspace = true }

--- a/crates/krilla/src/text/cid.rs
+++ b/crates/krilla/src/text/cid.rs
@@ -1,10 +1,10 @@
 use std::hash::Hash;
 use std::ops::DerefMut;
 
-use fxhash::FxHashMap;
 use pdf_writer::types::{CidFontType, FontFlags, SystemInfo, UnicodeCmap};
 use pdf_writer::writers::WMode;
 use pdf_writer::{Chunk, Finish, Name, Ref, Str};
+use rustc_hash::FxHashMap;
 use skrifa::raw::tables::cff::Cff;
 use skrifa::raw::{TableProvider, TopLevelTable};
 use subsetter::GlyphRemapper;

--- a/crates/krilla/src/text/mod.rs
+++ b/crates/krilla/src/text/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 
 use crate::text::cid::CIDFont;
 use crate::text::type3::{ColoredGlyph, Type3Font, Type3FontMapper, Type3ID};

--- a/crates/krilla/src/text/type3.rs
+++ b/crates/krilla/src/text/type3.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 use std::hash::Hash;
 use std::ops::DerefMut;
 
-use fxhash::FxHashMap;
 use pdf_writer::types::{FontFlags, UnicodeCmap};
 use pdf_writer::writers::WMode;
 use pdf_writer::{Chunk, Content, Finish, Name, Ref, Str};
+use rustc_hash::FxHashMap;
 
 use super::{FontIdentifier, Type3Identifier};
 use crate::color::rgb;


### PR DESCRIPTION
This PR bumps comemo so that I can bump it in Typst. Krilla itself isn't affected by the breaking changes in comemo.

I also switched from `fxhash` to `rustc-hash` because `fxhash` is unmaintained. `rustc-hash` is very similar (it even exposes the name `FxHashMap` for backwards compatibility) and actually slightly faster in some cases. I already switched the hasher in `subsetter`, so I bumped that here, too. With these changes `fxhash` is complete gone from krilla's and Typst's dependency tree.