### PR TITLE
More unified api for table header tag attribute

### DIFF
--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -414,8 +414,7 @@ fn tagging_table_header_and_footer(document: &mut Document) {
             cell_text(&mut surface, x, y, &format!("body {} {}", x + 1, y + 1));
             surface.end_tagged();
 
-            let headers = [header_id(x)];
-            let tag = Tag::TD.with_headers(headers);
+            let tag = Tag::TD.with_headers(Some([header_id(x)]));
             row.push(TagGroup::with_children(tag, vec![Node::Leaf(text)]));
         }
         body.push(row);
@@ -429,7 +428,7 @@ fn tagging_table_header_and_footer(document: &mut Document) {
         let cell = Tag::TD
             .with_row_span(Some(NonZeroU32::new(2).unwrap()))
             .with_col_span(Some(NonZeroU32::new(3).unwrap()))
-            .with_headers((0..3).map(header_id));
+            .with_headers(Some((0..3).map(header_id)));
         let cell = TagGroup::with_children(cell, vec![Node::Leaf(text)]);
 
         let row = TagGroup::with_children(Tag::TR, vec![Node::Group(cell)]);
@@ -638,7 +637,7 @@ fn tagging_unknown_header_tag_id() {
     let loc_1 = loc(1);
     let group_1 = TagGroup::new(
         Tag::TD
-            .with_headers([id.clone()])
+            .with_headers(Some([id.clone()]))
             .with_location(Some(loc_1)),
     );
 

--- a/crates/krilla/src/interchange/tagging/generated.rs
+++ b/crates/krilla/src/interchange/tagging/generated.rs
@@ -2910,8 +2910,8 @@ impl Tag<kind::TH> {
     /// evaluated.
     ///
     /// This allows specifying header hierarchies inside tables.
-    pub fn set_headers(&mut self, headers: impl IntoIterator<Item = TagId>) {
-        self.inner.set_table(TableAttr::CellHeaders(headers.into_iter().collect()));
+    pub fn set_headers(&mut self, headers: Option<impl IntoIterator<Item = TagId>>) {
+        self.inner.set_or_remove_table(TableAttr::CELL_HEADERS, headers.map(|ids| ids.into_iter().collect()).map(TableAttr::CellHeaders));
     }
 
     /// Set the list of headers associated with a table cell.
@@ -2921,7 +2921,7 @@ impl Tag<kind::TH> {
     /// evaluated.
     ///
     /// This allows specifying header hierarchies inside tables.
-    pub fn with_headers(mut self, headers: impl IntoIterator<Item = TagId>) -> Self {
+    pub fn with_headers(mut self, headers: Option<impl IntoIterator<Item = TagId>>) -> Self {
         self.set_headers(headers);
         self
     }
@@ -3083,8 +3083,8 @@ impl Tag<kind::TD> {
     /// evaluated.
     ///
     /// This allows specifying header hierarchies inside tables.
-    pub fn set_headers(&mut self, headers: impl IntoIterator<Item = TagId>) {
-        self.inner.set_table(TableAttr::CellHeaders(headers.into_iter().collect()));
+    pub fn set_headers(&mut self, headers: Option<impl IntoIterator<Item = TagId>>) {
+        self.inner.set_or_remove_table(TableAttr::CELL_HEADERS, headers.map(|ids| ids.into_iter().collect()).map(TableAttr::CellHeaders));
     }
 
     /// Set the list of headers associated with a table cell.
@@ -3094,7 +3094,7 @@ impl Tag<kind::TD> {
     /// evaluated.
     ///
     /// This allows specifying header hierarchies inside tables.
-    pub fn with_headers(mut self, headers: impl IntoIterator<Item = TagId>) -> Self {
+    pub fn with_headers(mut self, headers: Option<impl IntoIterator<Item = TagId>>) -> Self {
         self.set_headers(headers);
         self
     }

--- a/crates/krilla/src/interchange/tagging/tag.rs
+++ b/crates/krilla/src/interchange/tagging/tag.rs
@@ -36,7 +36,7 @@ impl TagKind {
 /// let tag = Tag::TH(TableHeaderScope::Row)
 ///     .with_id(Some(TagId::from(*b"this id")))
 ///     .with_col_span(Some(NonZeroU32::new(3).unwrap()))
-///     .with_headers([TagId::from(*b"parent id")])
+///     .with_headers(Some([TagId::from(*b"parent id")]))
 ///     .with_width(Some(250.0))
 ///     .with_height(Some(100.0));
 /// let group = TagGroup::new(tag);


### PR DESCRIPTION
This brings the table headers accessors more in line with other ones. Accepting an `Option` allows removing them again by passing the `None` value.
It also removes some special cases for `"Custom"` accessors in the code generation.