### PR TITLE
Enforce valid mime types

### DIFF
--- a/crates/krilla-tests/src/embed.rs
+++ b/crates/krilla-tests/src/embed.rs
@@ -1,5 +1,5 @@
 use krilla::configure::ValidationError;
-use krilla::embed::{AssociationKind, EmbedError, EmbeddedFile};
+use krilla::embed::{AssociationKind, EmbedError, EmbeddedFile, MimeType};
 use krilla::error::KrillaError;
 use krilla::metadata::{DateTime, Metadata};
 use krilla::tagging::TagTree;
@@ -12,7 +12,7 @@ pub(crate) fn file_1() -> EmbeddedFile {
     let data = std::fs::read(ASSETS_PATH.join("emojis.txt")).unwrap();
     EmbeddedFile {
         path: "emojis.txt".to_string(),
-        mime_type: Some("text/txt".to_string()),
+        mime_type: Some(MimeType::new("text/txt").unwrap()),
         description: Some("The description of the file.".to_string()),
         association_kind: AssociationKind::Supplement,
         data: data.into(),
@@ -27,7 +27,7 @@ fn file_2() -> EmbeddedFile {
         .unwrap();
     EmbeddedFile {
         path: "image.svg".to_string(),
-        mime_type: Some("image/svg+xml".to_string()),
+        mime_type: Some(MimeType::new("image/svg+xml").unwrap()),
         description: Some("A nice SVG image!".to_string()),
         association_kind: AssociationKind::Supplement,
         modification_date: Some(DateTime::new(2001)),
@@ -42,7 +42,7 @@ fn file_3() -> EmbeddedFile {
 
     EmbeddedFile {
         path: "rgb8.png".to_string(),
-        mime_type: Some("image/png".to_string()),
+        mime_type: Some(MimeType::new("image/png").unwrap()),
         description: Some("A nice picture.".to_string()),
         association_kind: AssociationKind::Unspecified,
         data: data.into(),
@@ -57,7 +57,7 @@ fn file_4() -> EmbeddedFile {
 
     EmbeddedFile {
         path: "rgb8.gif".to_string(),
-        mime_type: Some("image/gif".to_string()),
+        mime_type: Some(MimeType::new("image/gif").unwrap()),
         description: Some("A nice gif.".to_string()),
         association_kind: AssociationKind::Unspecified,
         modification_date: Some(DateTime::new(2001)),

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -8,9 +8,9 @@ use std::num::NonZeroU64;
 
 use crate::color::rgb;
 use crate::content::ContentBuilder;
+use crate::geom::Path;
 #[cfg(any(feature = "raster-images", feature = "pdf"))]
 use crate::geom::Size;
-use crate::geom::{Path, Rect};
 use crate::geom::{Point, Transform};
 use crate::graphic::Graphic;
 use crate::graphics::blend::BlendMode;
@@ -419,6 +419,8 @@ impl<'a> Surface<'a> {
     #[cfg(feature = "pdf")]
     /// Embed a single PDF page with the given dimensions.
     pub fn draw_pdf_page(&mut self, pdf: &PdfDocument, size: Size, page_idx: usize) {
+        use crate::geom::Rect;
+
         let obj_ref = self.sc.embed_pdf_page_as_xobject(pdf, page_idx);
         // If the user provided an invalid page index, we will detect this later on anyway, so
         // just use dummy dimensions here.


### PR DESCRIPTION
Using an invalid mime type will lead to validation failing in veraPDF, so enforcing this via a check seems like a good choice to me.