### PR TITLE
Update PDF/UA-1 documentation

### DIFF
--- a/crates/krilla/src/configure/PDF_UA1.md
+++ b/crates/krilla/src/configure/PDF_UA1.md
@@ -59,7 +59,7 @@ See `README.md` for the meaning of each color.
 - The information there is hardly enforceable in an automated way, so not documented yet. 🟠
 
 7.4.3:
-- krilla does not support heading levels higher than 6. 🔵
+- krilla adds tags for heading levels higher than 6 as prescribed. 🟢
 
 7.4.4:
 - The information there is hardly enforceable in an automated way, so not documented yet. 🟠


### PR DESCRIPTION
State that Krilla supports heading levels higher than six.