### PR TITLE
Encode single glyphs without X offset with `Tj` instead of `TJ`

### DIFF
--- a/refs/snapshots/font_type3_pdf_14.txt
+++ b/refs/snapshots/font_type3_pdf_14.txt
@@ -175,7 +175,7 @@ endobj
 
 7 0 obj
 <<
-  /Length 75
+  /Length 73
 >>
 stream
 q
@@ -185,7 +185,7 @@ BT
 0 Tr
 /f0 25 Tf
 1 0 0 -1 0 25 Tm
-[(\000)] TJ
+(\000) Tj
 ET
 Q
 endstream
@@ -208,13 +208,13 @@ xref
 0000001314 00000 n
 0000002610 00000 n
 0000002805 00000 n
-0000002933 00000 n
+0000002931 00000 n
 trailer
 <<
   /Size 9
   /Root 8 0 R
-  /ID [(yyLkqURd4S/NMlfqzyInuQ==) (yyLkqURd4S/NMlfqzyInuQ==)]
+  /ID [(eKVwRJWLDEJgkU4tfjp7yQ==) (eKVwRJWLDEJgkU4tfjp7yQ==)]
 >>
 startxref
-2987
+2985
 %%EOF

--- a/refs/snapshots/font_wrong_metrics.txt
+++ b/refs/snapshots/font_wrong_metrics.txt
@@ -153,7 +153,7 @@ endobj
 
 9 0 obj
 <<
-  /Length 79
+  /Length 77
 >>
 stream
 q
@@ -163,7 +163,7 @@ BT
 0 Tr
 /f0 25 Tf
 1 0 0 -1 0 25 Tm
-[(\000\001)] TJ
+(\000\001) Tj
 ET
 Q
 endstream
@@ -188,13 +188,13 @@ xref
 0000001562 00000 n
 0000003244 00000 n
 0000003439 00000 n
-0000003571 00000 n
+0000003569 00000 n
 trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(/3kVuRKSUX9Uwg3IowJXUA==) (/3kVuRKSUX9Uwg3IowJXUA==)]
+  /ID [(dTmPw4sTQZOdG3fE6gpiSA==) (dTmPw4sTQZOdG3fE6gpiSA==)]
 >>
 startxref
-3626
+3624
 %%EOF

--- a/refs/snapshots/font_wrong_metrics_2.txt
+++ b/refs/snapshots/font_wrong_metrics_2.txt
@@ -243,7 +243,7 @@ endobj
 
 9 0 obj
 <<
-  /Length 79
+  /Length 77
 >>
 stream
 q
@@ -253,7 +253,7 @@ BT
 0 Tr
 /f0 25 Tf
 1 0 0 -1 0 25 Tm
-[(\000\001)] TJ
+(\000\001) Tj
 ET
 Q
 endstream
@@ -278,13 +278,13 @@ xref
 0000001591 00000 n
 0000009675 00000 n
 0000009870 00000 n
-0000010002 00000 n
+0000010000 00000 n
 trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(phwWlJAJjef1FKOdoIjptw==) (phwWlJAJjef1FKOdoIjptw==)]
+  /ID [(unAIr1Tea/C4ZEQw6sduqQ==) (unAIr1Tea/C4ZEQw6sduqQ==)]
 >>
 startxref
-10057
+10055
 %%EOF

--- a/refs/snapshots/text_complex.txt
+++ b/refs/snapshots/text_complex.txt
@@ -202,7 +202,7 @@ endobj
 
 9 0 obj
 <<
-  /Length 782
+  /Length 780
 >>
 stream
 q
@@ -260,7 +260,7 @@ EMC
 0 Tr
 /f0 16 Tf
 1 0 0 -1 123.871994 50 Tm
-[(\000\017)] TJ
+(\000\017) Tj
 ET
 Q
 endstream
@@ -285,13 +285,13 @@ xref
 0000001854 00000 n
 0000006283 00000 n
 0000006478 00000 n
-0000007314 00000 n
+0000007312 00000 n
 trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(TojswRa+L+hff/9xCwnIzQ==) (TojswRa+L+hff/9xCwnIzQ==)]
+  /ID [(E13K1pYnGLAh8lsssdB5wQ==) (E13K1pYnGLAh8lsssdB5wQ==)]
 >>
 startxref
-7369
+7367
 %%EOF

--- a/refs/snapshots/text_complex_2.txt
+++ b/refs/snapshots/text_complex_2.txt
@@ -190,7 +190,7 @@ endobj
 
 9 0 obj
 <<
-  /Length 764
+  /Length 760
 >>
 stream
 q
@@ -228,7 +228,7 @@ EMC
 0 Tr
 /f0 16 Tf
 1 0 0 -1 42.848 50 Tm
-[(\000\006)] TJ
+(\000\006) Tj
 /Span <<
   /ActualText <FEFF090B0952>
 >> BDC
@@ -240,7 +240,7 @@ EMC
 0 Tr
 /f0 16 Tf
 1 0 0 -1 60.656 50 Tm
-[(\000\f)] TJ
+(\000\f) Tj
 /Span <<
   /ActualText <FEFF0935093E>
 >> BDC
@@ -273,13 +273,13 @@ xref
 0000001791 00000 n
 0000005635 00000 n
 0000005830 00000 n
-0000006648 00000 n
+0000006644 00000 n
 trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(PvhU9AysiRJsaBFRvTV5fg==) (PvhU9AysiRJsaBFRvTV5fg==)]
+  /ID [(H4sojb1kb1NfpG04nYsKKg==) (H4sojb1kb1NfpG04nYsKKg==)]
 >>
 startxref
-6703
+6699
 %%EOF

--- a/refs/snapshots/text_complex_3.txt
+++ b/refs/snapshots/text_complex_3.txt
@@ -235,7 +235,7 @@ endobj
 
 9 0 obj
 <<
-  /Length 1881
+  /Length 1871
 >>
 stream
 q
@@ -257,7 +257,7 @@ EMC
 0 Tr
 /f0 12 Tf
 1 0 0 -1 22.56 50 Tm
-[(\000\005)] TJ
+(\000\005) Tj
 /Span <<
   /ActualText <FEFF092E0948>
 >> BDC
@@ -277,7 +277,7 @@ EMC
 0 Tr
 /f0 12 Tf
 1 0 0 -1 44.664 50 Tm
-[(\000\002)] TJ
+(\000\002) Tj
 /Span <<
   /ActualText <FEFF092F09410952>
 >> BDC
@@ -309,7 +309,7 @@ EMC
 0 Tr
 /f0 12 Tf
 1 0 0 -1 79.920006 50 Tm
-[(\000\002)] TJ
+(\000\002) Tj
 /Span <<
   /ActualText <FEFF090B0952>
 >> BDC
@@ -321,7 +321,7 @@ EMC
 0 Tr
 /f0 12 Tf
 1 0 0 -1 93.27601 50 Tm
-[(\000\021)] TJ
+(\000\021) Tj
 /Span <<
   /ActualText <FEFF0935093E>
 >> BDC
@@ -333,7 +333,7 @@ EMC
 0 Tr
 /f0 12 Tf
 1 0 0 -1 107.28001 50 Tm
-[(\000\002)] TJ
+(\000\002) Tj
 /Span <<
   /ActualText <FEFF090B0952>
 >> BDC
@@ -394,13 +394,13 @@ xref
 0000002068 00000 n
 0000008426 00000 n
 0000008621 00000 n
-0000010557 00000 n
+0000010547 00000 n
 trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(nlvCVFMos6LuTUPeYwO4sg==) (nlvCVFMos6LuTUPeYwO4sg==)]
+  /ID [(1ns7bMPGUQQrabmPjHBmHw==) (1ns7bMPGUQQrabmPjHBmHw==)]
 >>
 startxref
-10612
+10602
 %%EOF

--- a/refs/snapshots/text_complex_4.txt
+++ b/refs/snapshots/text_complex_4.txt
@@ -236,7 +236,7 @@ endobj
 
 9 0 obj
 <<
-  /Length 2807
+  /Length 2791
 >>
 stream
 q
@@ -278,7 +278,7 @@ EMC
 0 Tr
 /f0 10 Tf
 1 0 0 -1 39.880005 50 Tm
-[(\000\n)] TJ
+(\000\n) Tj
 /Span <<
   /ActualText <FEFF0935093F0952>
 >> BDC
@@ -306,7 +306,7 @@ EMC
 0 Tr
 /f0 10 Tf
 1 0 0 -1 65.22 50 Tm
-[(\000\n)] TJ
+(\000\n) Tj
 /Span <<
   /ActualText <FEFF092E0952>
 >> BDC
@@ -318,7 +318,7 @@ EMC
 0 Tr
 /f0 10 Tf
 1 0 0 -1 73.8 50 Tm
-[(\000\022)] TJ
+(\000\022) Tj
 /Span <<
   /ActualText <FEFF0924094B0952>
 >> BDC
@@ -350,14 +350,14 @@ EMC
 0 Tr
 /f0 10 Tf
 1 0 0 -1 119.66 50 Tm
-[(\000\027)] TJ
+(\000\027) Tj
 /Span <<
   /ActualText <FEFF0935>
 >> BDC
 0 Tr
 /f0 10 Tf
 1 0 0 -1 123.75 50 Tm
-[(\000\003)] TJ
+(\000\003) Tj
 EMC
 0 Tr
 /f0 10 Tf
@@ -369,7 +369,7 @@ EMC
 0 Tr
 /f0 10 Tf
 1 0 0 -1 138.94 50 Tm
-[(\000\006)] TJ
+(\000\006) Tj
 EMC
 /Span <<
   /ActualText <FEFF09300951>
@@ -397,7 +397,7 @@ EMC
 0 Tr
 /f0 10 Tf
 1 0 0 -1 159.69 50 Tm
-[(\000\021)] TJ
+(\000\021) Tj
 EMC
 /Span <<
   /ActualText <FEFF0928093E0951>
@@ -410,7 +410,7 @@ EMC
 0 Tr
 /f0 10 Tf
 1 0 0 -1 173.81 50 Tm
-[(\000\n)] TJ
+(\000\n) Tj
 /Span <<
   /ActualText <FEFF0926093F0952>
 >> BDC
@@ -459,13 +459,13 @@ xref
 0000002148 00000 n
 0000008421 00000 n
 0000008616 00000 n
-0000011478 00000 n
+0000011462 00000 n
 trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(mFssIay89Y2Sz3IOgX5BCw==) (mFssIay89Y2Sz3IOgX5BCw==)]
+  /ID [(AcJ8a3oP4TGh9dhafVsfQw==) (AcJ8a3oP4TGh9dhafVsfQw==)]
 >>
 startxref
-11533
+11517
 %%EOF

--- a/refs/snapshots/text_small_caps.txt
+++ b/refs/snapshots/text_small_caps.txt
@@ -144,7 +144,7 @@ endobj
 
 9 0 obj
 <<
-  /Length 173
+  /Length 169
 >>
 stream
 q
@@ -154,14 +154,14 @@ BT
 0 Tr
 /f0 12 Tf
 1 0 0 -1 0 50 Tm
-[(\000\001)] TJ
+(\000\001) Tj
 /Span <<
   /ActualText (t)
 >> BDC
 0 Tr
 /f0 12 Tf
 1 0 0 -1 6.3479996 50 Tm
-[(\000\001)] TJ
+(\000\001) Tj
 EMC
 ET
 Q
@@ -187,13 +187,13 @@ xref
 0000001565 00000 n
 0000002625 00000 n
 0000002820 00000 n
-0000003047 00000 n
+0000003043 00000 n
 trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(tgMb+CwZIhjoMJPrbY/jjQ==) (tgMb+CwZIhjoMJPrbY/jjQ==)]
+  /ID [(bclRFd8ghR7/xatFF66cAQ==) (bclRFd8ghR7/xatFF66cAQ==)]
 >>
 startxref
-3102
+3098
 %%EOF


### PR DESCRIPTION
If it's just a single glyph and without an x_offset, there is no need for individual positioning, so we can use `Tj` instead of `TJ`. The reason to do this is that Acrobat's copy-paste is a bit buggy if `/ActualText` is used at the end of a line, but only if `TJ` is used. With `Tj`, it's fine.