### PR TITLE
Fix returned lifetime of Validator and PdfVersion as_str methods

### DIFF
--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -732,7 +732,7 @@ impl Validator {
     }
 
     /// The string representation of the validator.
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Validator::None => "None",
             Validator::A1_A => "PDF/A1-A",

--- a/crates/krilla/src/configure/version.rs
+++ b/crates/krilla/src/configure/version.rs
@@ -33,7 +33,7 @@ impl PdfVersion {
     }
 
     /// Get a string representation of the PDF version.
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(self) -> &'static str {
         match self {
             PdfVersion::Pdf14 => "PDF 1.4",
             PdfVersion::Pdf15 => "PDF 1.5",


### PR DESCRIPTION
Just fix a minor annoyance, because with the current methods suggest the returned string borrows from `PdfVersion`/`Validator`.