### PR TITLE
Use `u8` instead of `f32` for `NaiveRgbColor` components

### DIFF
--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -559,8 +559,8 @@ fn tagging_div_and_border_color(document: &mut Document) {
     surface.finish();
     page.finish();
 
-    let red = NaiveRgbColor::new(1.0, 0.0, 0.0);
-    let blue = NaiveRgbColor::new(0.0, 0.0, 1.0);
+    let red = NaiveRgbColor::new(0xFF, 0x00, 0x00);
+    let blue = NaiveRgbColor::new(0x00, 0x00, 0xFF);
     let mut div = TagGroup::new(
         Tag::Div
             .with_border_color(Some(Sides::new(red, blue, red, blue)))

--- a/crates/krilla/src/interchange/tagging/fmt.rs
+++ b/crates/krilla/src/interchange/tagging/fmt.rs
@@ -452,9 +452,9 @@ impl<T: PartialEq + ValueOutput> Output for Sides<T> {
 impl ValueOutput for NaiveRgbColor {}
 impl Output for NaiveRgbColor {
     fn output_indent(&self, f: &mut impl std::fmt::Write, _: Indent) -> std::fmt::Result {
-        let r = (255.0 * self.red).round() as u8;
-        let g = (255.0 * self.green).round() as u8;
-        let b = (255.0 * self.blue).round() as u8;
+        let r = self.red;
+        let g = self.green;
+        let b = self.blue;
         write!(f, "#{r:02x}{g:02x}{b:02x}")
     }
 }
@@ -629,10 +629,10 @@ mod tests {
         sec.push(figure);
 
         let border_color = Sides::new(
-            NaiveRgbColor::new(0.1, 0.4, 1.0),
-            NaiveRgbColor::new(0.3, 0.5, 0.2),
-            NaiveRgbColor::new(0.3, 0.4, 0.3),
-            NaiveRgbColor::new(0.0, 0.7, 0.2),
+            NaiveRgbColor::new(0x1A, 0x66, 0xFF),
+            NaiveRgbColor::new(0x4D, 0x80, 0x33),
+            NaiveRgbColor::new(0x4D, 0x66, 0x4D),
+            NaiveRgbColor::new(0x00, 0xB3, 0x33),
         );
         let table = Tag::Table
             .with_border_color(Some(border_color))

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -834,7 +834,7 @@ impl TagGroup {
                 }
                 LayoutAttr::BorderColor(sides) => {
                     if pdf_version >= PdfVersion::Pdf15 {
-                        let sides = sides.map_pdf(NaiveRgbColor::into_array);
+                        let sides = sides.map_pdf(NaiveRgbColor::into_f32_array);
                         layout_attributes.get().border_color(sides);
                     }
                 }

--- a/crates/krilla/src/interchange/tagging/tag.rs
+++ b/crates/krilla/src/interchange/tagging/tag.rs
@@ -351,45 +351,50 @@ impl BBox {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NaiveRgbColor {
     /// The red component of the color.
-    pub red: f32,
+    pub red: u8,
     /// The green component of the color.
-    pub green: f32,
+    pub green: u8,
     /// The blue component of the color.
-    pub blue: f32,
+    pub blue: u8,
 }
 
 impl NaiveRgbColor {
     /// Create a new RGB color.
-    pub fn new(red: f32, green: f32, blue: f32) -> Self {
+    pub fn new(red: u8, green: u8, blue: u8) -> Self {
+        Self { red, green, blue }
+    }
+
+    /// Create a new RGB color from normalized floating point values.
+    pub fn new_f32(red: f32, green: f32, blue: f32) -> Self {
         if !(0.0..=1.0).contains(&red)
             || !(0.0..=1.0).contains(&green)
             || !(0.0..=1.0).contains(&blue)
         {
             panic!("RGB color components must be in the range [0.0, 1.0]");
         }
-
-        Self { red, green, blue }
+        Self {
+            red: (255.0 * red).round() as u8,
+            green: (255.0 * green).round() as u8,
+            blue: (255.0 * blue).round() as u8,
+        }
     }
 
     /// Convert the color into an array of f32 components for PDF serialization.
-    pub fn into_array(self) -> [f32; 3] {
-        [self.red, self.green, self.blue]
+    pub fn into_f32_array(self) -> [f32; 3] {
+        let normalize = |n| n as f32 / 255.0;
+        [self.red, self.green, self.blue].map(normalize)
     }
 }
 
 impl From<NaiveRgbColor> for crate::graphics::color::rgb::Color {
     fn from(color: NaiveRgbColor) -> Self {
-        crate::graphics::color::rgb::Color::new(
-            (color.red * 255.0) as u8,
-            (color.green * 255.0) as u8,
-            (color.blue * 255.0) as u8,
-        )
+        crate::graphics::color::rgb::Color::new(color.red, color.green, color.blue)
     }
 }
 
 impl From<NaiveRgbColor> for [f32; 3] {
     fn from(color: NaiveRgbColor) -> Self {
-        color.into_array()
+        color.into_f32_array()
     }
 }
 


### PR DESCRIPTION
It turns out `Sides<NaiveRgbColor>` was the largest attribute. And since `Tag` uses a `SmallVec<[Attr; 1]>` to store one attribute on the stack, this increased the size of all tags. Using `u8` instead of `f32` for the color components reduces the size of `Attr` and thus also `Tag` by 16 bytes.

I've kept a constructor which takes `f32` color values and panics if the values aren't normalized, but we can also remove the `new_f32` function.