### PR TITLE
Fix the names of ISO PDF standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In addition to that, the library also supports the following PDF features:
 - Adding document metadata.
 - Creating accessible PDFs via tagged PDF (experimental!).
 - Support for different PDF versions (1.4, 1.5, 1.6, 1.7, 2.0).
-- Support for validated some validated export modes (PDF/A1, PDF/A2, PDF/A3, PDF/A4, PDF/UA1).
+- Support for validated some validated export modes (PDF/A-1, PDF/A-2, PDF/A-3, PDF/A-4, PDF/UA-1).
 
 ## Scope
 This crate labels itself as a high-level crate, and this is what it is: It abstracts away most

--- a/crates/krilla/src/configure/PDF_A1.md
+++ b/crates/krilla/src/configure/PDF_A1.md
@@ -1,5 +1,5 @@
 # Description
-PDF-A/1 requires PDF a version <= 1.4 and defines three conformance levels, 
+PDF/A-1 requires PDF a version <= 1.4 and defines three conformance levels, 
 in the following order from less strict to more strict:
 - Level B
 - Level A
@@ -208,7 +208,7 @@ when a PostScript function is used. 🟢
 6.8.6: krilla currently does not support any non-textual annotations. 🔵
 
 
-NOTE: krilla will discard any alt text / abbreviations specifications in PDF/A1, because it's based on PDF 1.4,
+NOTE: krilla will discard any alt text / abbreviations specifications in PDF/A-1, because it's based on PDF 1.4,
 and we define them inline as properties to spans, which
 is actually only available for PDF >= 1.5. Maybe we
 can fix this in the future.

--- a/crates/krilla/src/configure/PDF_A2.md
+++ b/crates/krilla/src/configure/PDF_A2.md
@@ -1,5 +1,5 @@
 # Description
-PDF-A/2 requires PDF a version <= 1.7 and defines three conformance levels, 
+PDF/A-2 requires PDF a version <= 1.7 and defines three conformance levels, 
 in the following order from less strict to more strict:
 - Level B
 - Level U

--- a/crates/krilla/src/configure/PDF_A3.md
+++ b/crates/krilla/src/configure/PDF_A3.md
@@ -1,11 +1,11 @@
 # Description
-PDF-A/3 requires PDF a version <= 1.7 and defines three conformance levels, 
+PDF/A-3 requires PDF a version <= 1.7 and defines three conformance levels, 
 in the following order from less strict to more strict:
 - Level B
 - Level U
 - Level A
 
-It is exactly the same as PDF-A/2, except for clause 6.8.
+It is exactly the same as PDF/A-2, except for clause 6.8.
 
 See `README.md` for the meaning of each subclause.
 

--- a/crates/krilla/src/configure/PDF_A4.md
+++ b/crates/krilla/src/configure/PDF_A4.md
@@ -1,5 +1,5 @@
 # Description
-PDF-A/4 requires PDF a version 2.0 and defines three conformance levels,
+PDF/A-4 requires PDF a version 2.0 and defines three conformance levels,
 in the following order from less strict to more strict:
 - Level B
 - Level U

--- a/crates/krilla/src/configure/PDF_UA1.md
+++ b/crates/krilla/src/configure/PDF_UA1.md
@@ -1,5 +1,5 @@
 # Description
-PDF-UA/1 requires a version <= PDF 1.7.
+PDF/UA-1 requires a version <= PDF 1.7.
 
 See `README.md` for the meaning of each color.
 

--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -90,7 +90,7 @@ pub enum ValidationError {
     /// an empty string). Otherwise, it was mapped to that codepoint.
     InvalidCodepointMapping(Font, GlyphId, Option<char>, Option<Location>),
     /// A glyph was mapped to a codepoint in the Unicode private use area, which is forbidden
-    /// by some standards, like for example PDF/A2-A.
+    /// by some standards, like for example PDF/A-2a.
     // Note that the standard doesn't explicitly forbid it, but instead requires an ActualText
     // attribute to be present. But we just completely forbid it, for simplicity.
     UnicodePrivateArea(Font, GlyphId, char, Option<Location>),
@@ -112,7 +112,7 @@ pub enum ValidationError {
     // We need this because for some standards we need to add the
     // xmp:History attribute.
     MissingDocumentDate,
-    /// The PDF contains transparency, which is forbidden by some standards (e.g. PDF/A1).
+    /// The PDF contains transparency, which is forbidden by some standards (e.g. PDF/A-1).
     Transparency(Option<Location>),
     /// The PDF contains an image with `interpolate` set to `true`.
     ImageInterpolation(Option<Location>),
@@ -136,19 +136,19 @@ pub enum Validator {
     /// **Requirements**: -
     #[default]
     None,
-    /// The validator for the PDF/A1-A standard.
+    /// The validator for the PDF/A-1a standard.
     ///
     /// **Requirements**:
     ///
     A1_A,
-    /// The validator for the PDF/A1-B standard.
+    /// The validator for the PDF/A-1b standard.
     ///
     /// **Requirements**: -
     A1_B,
-    /// The validator for the PDF/A2-A standard.
+    /// The validator for the PDF/A-2a standard.
     ///
     /// **Requirements**:
-    /// - All requirements of PDF/A2-B.
+    /// - All requirements of PDF/A-2b.
     /// - You need to follow all requirements outlined in the _Other Notes_ section of the
     ///   [`tagging`] module.
     /// - You need to follow all best practices when using [tags](`crate::interchange::tagging::Tag`), as outlined in the documentation
@@ -165,31 +165,31 @@ pub enum Validator {
     ///
     /// [`tagging`]: crate::interchange::tagging
     A2_A,
-    /// The validator for the PDF/A2-B standard.
+    /// The validator for the PDF/A-2b standard.
     ///
     /// **Requirements**:
     /// - You should only use fonts that are legally embeddable in a file for unlimited,
     ///   universal rendering.
     A2_B,
-    /// The validator for the PDF/A2-U standard.
+    /// The validator for the PDF/A-2u standard.
     ///
     /// **Requirements**:
-    /// - All requirements of PDF/A2-B
+    /// - All requirements of PDF/A-2b
     A2_U,
-    /// The validator for the PDF/A3-A standard.
+    /// The validator for the PDF/A-3a standard.
     ///
     /// **Requirements**:
-    /// - All requirements of PDF/A2-A
+    /// - All requirements of PDF/A-2a
     A3_A,
-    /// The validator for the PDF/A3-B standard.
+    /// The validator for the PDF/A-3b standard.
     ///
     /// **Requirements**:
-    /// - All requirements of PDF/A2-B
+    /// - All requirements of PDF/A-2b
     A3_B,
-    /// The validator for the PDF/A3-U standard.
+    /// The validator for the PDF/A-3u standard.
     ///
     /// **Requirements**:
-    /// - All requirements of PDF/A2-B
+    /// - All requirements of PDF/A-2b
     A3_U,
     /// The validator for the PDF/UA-1 standard.
     /// NOTE: THIS EXPORT MODE IS EXPERIMENTAL AND SHOULDN'T BE USED IN PRODUCTION YET!
@@ -209,7 +209,7 @@ pub enum Validator {
     /// - You should make use of the `Alt`, `ActualText`, `Lang` and `Expansion` attributes
     ///   whenever possible.
     /// - Usually, you can provide an empty string as `Lang` to indicate that a language is unknown.
-    ///   You should not do that in PDF-UA.
+    ///   You should not do that in PDF/UA.
     /// - Stretchable characters (such as brackets, which often consist of several glyphs)
     ///   should be marked accordingly with `ActualText`.
     ///
@@ -263,20 +263,20 @@ pub enum Validator {
     ///
     /// [`TagKind`]: crate::interchange::tagging::TagKind
     UA1,
-    /// The validator for the PDF/A4 standard.
+    /// The validator for the PDF/A-4 standard.
     ///
     /// **Requirements**:
     /// - While not required, it's recommended to enable tagging.
     A4,
-    /// The validator for the PDF/A4f standard.
+    /// The validator for the PDF/A-4f standard.
     ///
     /// **Requirements**:
-    /// - All requirements of PDF/A4
+    /// - All requirements of PDF/A-4
     A4F,
-    /// The validator for the PDF/A4e standard.
+    /// The validator for the PDF/A-4e standard.
     ///
     /// **Requirements**:
-    /// - All requirements of PDF/A4
+    /// - All requirements of PDF/A-4
     A4E,
 }
 
@@ -307,7 +307,7 @@ impl Validator {
                 ValidationError::MissingAnnotationAltText(_) => false,
                 ValidationError::Transparency(_) => true,
                 ValidationError::ImageInterpolation(_) => true,
-                // PDF/A1 doesn't strictly forbid, but it disallows the EF key,
+                // PDF/A-1 doesn't strictly forbid, but it disallows the EF key,
                 // which we always insert. So we just forbid it overall.
                 ValidationError::EmbeddedFile(e, _) => match e {
                     EmbedError::Existence => true,
@@ -345,7 +345,7 @@ impl Validator {
                 ValidationError::MissingAnnotationAltText(_) => false,
                 ValidationError::Transparency(_) => false,
                 ValidationError::ImageInterpolation(_) => true,
-                // Also not strictly forbidden, but we can't ensure that it is PDF/A2 compliant,
+                // Also not strictly forbidden, but we can't ensure that it is PDF/A-2 compliant,
                 // so we just forbid it completely.
                 ValidationError::EmbeddedFile(e, _) => match e {
                     EmbedError::Existence => true,
@@ -718,7 +718,7 @@ impl Validator {
         match self {
             // PDF 2.0 _does_ support associated files. However, in this case the document has to
             // provide a modification date, since it's a required field. Therefore, it's easier to
-            // just use the associated files feature, apart from PDF/A3.
+            // just use the associated files feature, apart from PDF/A-3.
             Validator::None => false,
             Validator::A3_A | Validator::A3_B | Validator::A3_U => true,
             Validator::A4 | Validator::A4F | Validator::A4E => true,
@@ -735,18 +735,18 @@ impl Validator {
     pub fn as_str(self) -> &'static str {
         match self {
             Validator::None => "None",
-            Validator::A1_A => "PDF/A1-A",
-            Validator::A1_B => "PDF/A1-B",
-            Validator::A2_A => "PDF/A2-A",
-            Validator::A2_B => "PDF/A2-B",
-            Validator::A2_U => "PDF/A2-U",
-            Validator::A3_A => "PDF/A3-A",
-            Validator::A3_B => "PDF/A3-B",
-            Validator::A3_U => "PDF/A3-U",
-            Validator::A4 => "PDF/A4",
-            Validator::A4F => "PDF/A4f",
-            Validator::A4E => "PDF/A4e",
-            Validator::UA1 => "PDF/UA1",
+            Validator::A1_A => "PDF/A-1a",
+            Validator::A1_B => "PDF/A-1b",
+            Validator::A2_A => "PDF/A-2a",
+            Validator::A2_B => "PDF/A-2b",
+            Validator::A2_U => "PDF/A-2u",
+            Validator::A3_A => "PDF/A-3a",
+            Validator::A3_B => "PDF/A-3b",
+            Validator::A3_U => "PDF/A-3u",
+            Validator::A4 => "PDF/A-4",
+            Validator::A4F => "PDF/A-4f",
+            Validator::A4E => "PDF/A-4e",
+            Validator::UA1 => "PDF/UA-1",
         }
     }
 }

--- a/crates/krilla/src/interchange/metadata.rs
+++ b/crates/krilla/src/interchange/metadata.rs
@@ -62,7 +62,7 @@ impl Metadata {
 
     /// The main language of the document, as an RFC 3066 language tag.
     ///
-    /// This property is required for some export modes, like for example PDF/A3-A
+    /// This property is required for some export modes, like for example PDF/A-3a.
     pub fn language(mut self, language: String) -> Self {
         self.language = Some(language);
         self
@@ -377,7 +377,7 @@ impl DateTime {
 /// Converts a datetime to a pdf-writer date.
 pub(crate) fn pdf_date(date_time: DateTime) -> pdf_writer::Date {
     // We always assume a full date with all fields because for some reason
-    // Acrobat doesn't like PDF/A1 files without everything set.
+    // Acrobat doesn't like PDF/A-1 files without everything set.
     pdf_writer::Date::new(date_time.year)
         .month(date_time.month.unwrap_or(1))
         .day(date_time.day.unwrap_or(1))
@@ -399,7 +399,7 @@ fn xmp_date(datetime: DateTime) -> xmp_writer::DateTime {
     };
 
     // We always assume a full date with all fields because for some reason
-    // Acrobat doesn't like PDF/A1 files without everything set.
+    // Acrobat doesn't like PDF/A-1 files without everything set.
     xmp_writer::DateTime {
         year: datetime.year,
         month: Some(datetime.month.unwrap_or(1)),

--- a/crates/krilla/src/interchange/tagging/generate.toml
+++ b/crates/krilla/src/interchange/tagging/generate.toml
@@ -329,7 +329,7 @@ optional = [
 ]
 # Item of graphical content.
 #
-# Providing `alt_text` is required in some export modes, like for example PDF/UA1.
+# Providing `alt_text` is required in some export modes, like for example PDF/UA-1.
 [Tag.Figure]
 suggested = ["Struct::AltText"]
 optional = [
@@ -339,7 +339,7 @@ optional = [
 ]
 # A mathematical formula.
 #
-# Providing `alt_text` is required in some export modes, like for example PDF/UA1.
+# Providing `alt_text` is required in some export modes, like for example PDF/UA-1.
 [Tag.Formula]
 suggested = ["Struct::AltText"]
 optional = [

--- a/crates/krilla/src/interchange/tagging/generated.rs
+++ b/crates/krilla/src/interchange/tagging/generated.rs
@@ -111,11 +111,11 @@ pub enum TagKind {
     Annot(Tag<kind::Annot>),
     /// Item of graphical content.
     ///
-    /// Providing `alt_text` is required in some export modes, like for example PDF/UA1.
+    /// Providing `alt_text` is required in some export modes, like for example PDF/UA-1.
     Figure(Tag<kind::Figure>),
     /// A mathematical formula.
     ///
-    /// Providing `alt_text` is required in some export modes, like for example PDF/UA1.
+    /// Providing `alt_text` is required in some export modes, like for example PDF/UA-1.
     Formula(Tag<kind::Formula>),
     /// Non-structural element. A grouping element having no inherent structural significance;
     /// it serves solely for grouping purposes.
@@ -1668,13 +1668,13 @@ pub mod kind {
 
     /// Item of graphical content.
     ///
-    /// Providing `alt_text` is required in some export modes, like for example PDF/UA1.
+    /// Providing `alt_text` is required in some export modes, like for example PDF/UA-1.
     #[derive(Clone, Debug, PartialEq)]
     pub struct Figure;
 
     /// A mathematical formula.
     ///
-    /// Providing `alt_text` is required in some export modes, like for example PDF/UA1.
+    /// Providing `alt_text` is required in some export modes, like for example PDF/UA-1.
     #[derive(Clone, Debug, PartialEq)]
     pub struct Formula;
 
@@ -3902,7 +3902,7 @@ impl From<Tag<kind::Figure>> for TagKind {
 impl Tag<kind::Figure> {
     /// Item of graphical content.
     ///
-    /// Providing `alt_text` is required in some export modes, like for example PDF/UA1.
+    /// Providing `alt_text` is required in some export modes, like for example PDF/UA-1.
     #[allow(non_snake_case)]
     pub fn Figure(alt_text: Option<String>) -> Tag<kind::Figure> {
         let mut tag = Tag::new();
@@ -3970,7 +3970,7 @@ impl From<Tag<kind::Formula>> for TagKind {
 impl Tag<kind::Formula> {
     /// A mathematical formula.
     ///
-    /// Providing `alt_text` is required in some export modes, like for example PDF/UA1.
+    /// Providing `alt_text` is required in some export modes, like for example PDF/UA-1.
     #[allow(non_snake_case)]
     pub fn Formula(alt_text: Option<String>) -> Tag<kind::Formula> {
         let mut tag = Tag::new();

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -93,7 +93,7 @@ pub struct SerializeSettings {
     /// disable it dynamically, without having to make any changes to your code.
     ///
     /// Note that this value might be overridden depending on which validator
-    /// you use. For example, when exporting with PDF-UA, this value will always
+    /// you use. For example, when exporting with PDF/UA, this value will always
     /// be set to `true`.
     ///
     /// [`tagging`]: crate::interchange::tagging

--- a/crates/krilla/src/text/cid.rs
+++ b/crates/krilla/src/text/cid.rs
@@ -271,7 +271,7 @@ impl CIDFont {
         width_writer.finish();
         cid.finish();
 
-        // The only reason we write this in the first place is that PDF/A1-b requires
+        // The only reason we write this in the first place is that PDF/A-1b requires
         // a CIDSet.
         if !sc.serialize_settings().pdf_version().deprecates_cid_set() {
             let cid_stream_data = {


### PR DESCRIPTION
There were a wealth of spellings for standards like PDF/A-4f which this commit consolidates into the standard spellings.