### PR TITLE
Bump hayro-write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 [[package]]
 name = "hayro-syntax"
 version = "0.2.0"
-source = "git+https://github.com/LaurenzV/hayro?rev=cbebe75#cbebe75cbd131b97349a2f78507c508c0d01390d"
+source = "git+https://github.com/LaurenzV/hayro?rev=e62f9d8#e62f9d8849f62ab4296f98999b5aaef301dab0dd"
 dependencies = [
  "flate2",
  "kurbo",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "hayro-write"
 version = "0.2.0"
-source = "git+https://github.com/LaurenzV/hayro?rev=cbebe75#cbebe75cbd131b97349a2f78507c508c0d01390d"
+source = "git+https://github.com/LaurenzV/hayro?rev=e62f9d8#e62f9d8849f62ab4296f98999b5aaef301dab0dd"
 dependencies = [
  "flate2",
  "hayro-syntax",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ flate2 = {version = "1.1.0", default-features = false, features = ["zlib-rs"]}
 float-cmp = "0.10.0"
 fontdb = "0.23.0"
 gif = "0.13.1"
-hayro-write = { git = "https://github.com/LaurenzV/hayro", rev = "cbebe75" }
+hayro-write = { git = "https://github.com/LaurenzV/hayro", rev = "e62f9d8" }
 image = { version = "0.25.1", default-features = false }
 imagesize = "0.13.0"
 image-webp = "0.2.1"


### PR DESCRIPTION
This bumps `hayro-write` to a slightly newer commit, in which `hayro` also depends on `skrifa 0.33`.
At some point `skrifa`, `parley`, etc. should probably be upgraded to the newest versions. But the roadblock I currently hit was that `svgtypes` and `usvg` still depend on `kurbo 0.11`.