### PR TITLE
Check whether font is legally embeddable in validated export

### DIFF
--- a/crates/krilla/src/configure/PDF_A4.md
+++ b/crates/krilla/src/configure/PDF_A4.md
@@ -112,6 +112,7 @@ See `README.md` for the meaning of each color.
 - krilla ensures Unicode values are always greater than 0 and not equal to U+FEFF or U+FFFE. 🟢
 - krilla straight out forbids characters in the private use area. 🟢
 - krilla disallows the .notdef glyph in this export mode. 🟢
+- krilla checks the OpenType fsType field to ensure that fonts are legally embeddable. 🟢
 
 ## 6.3 Annotations
 

--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -94,6 +94,9 @@ pub enum ValidationError {
     // Note that the standard doesn't explicitly forbid it, but instead requires an ActualText
     // attribute to be present. But we just completely forbid it, for simplicity.
     UnicodePrivateArea(Font, GlyphId, char, Option<Location>),
+    /// A font has a license that requires explicit permission of the legal owner for embedding
+    /// but the standard requires font programs to be legally embeddable for universal rendering.
+    RestrictedLicense(Font),
     /// No document language was set via the metadata, even though it is required
     /// by the standard.
     NoDocumentLanguage,
@@ -299,6 +302,7 @@ impl Validator {
                     self.requires_codepoint_mappings()
                 }
                 ValidationError::UnicodePrivateArea(_, _, _, _) => false,
+                ValidationError::RestrictedLicense(_) => true,
                 ValidationError::NoDocumentLanguage => *self == Validator::A1_A,
                 ValidationError::NoDocumentTitle => false,
                 ValidationError::MissingAltText(_) => false,
@@ -337,6 +341,7 @@ impl Validator {
                     self.requires_codepoint_mappings()
                 }
                 ValidationError::UnicodePrivateArea(_, _, _, _) => *self == Validator::A2_A,
+                ValidationError::RestrictedLicense(_) => true,
                 ValidationError::NoDocumentLanguage => *self == Validator::A2_A,
                 ValidationError::NoDocumentTitle => false,
                 ValidationError::MissingAltText(_) => false,
@@ -375,6 +380,7 @@ impl Validator {
                     self.requires_codepoint_mappings()
                 }
                 ValidationError::UnicodePrivateArea(_, _, _, _) => *self == Validator::A3_A,
+                ValidationError::RestrictedLicense(_) => true,
                 ValidationError::NoDocumentLanguage => *self == Validator::A3_A,
                 ValidationError::NoDocumentTitle => false,
                 ValidationError::MissingAltText(_) => false,
@@ -408,6 +414,7 @@ impl Validator {
                 // Not strictly forbidden if we surround with actual text, but
                 // easier to just forbid it.
                 ValidationError::UnicodePrivateArea(_, _, _, _) => true,
+                ValidationError::RestrictedLicense(_) => true,
                 ValidationError::NoDocumentLanguage => false,
                 ValidationError::NoDocumentTitle => false,
                 ValidationError::MissingAltText(_) => false,
@@ -447,6 +454,7 @@ impl Validator {
                     self.requires_codepoint_mappings()
                 }
                 ValidationError::UnicodePrivateArea(_, _, _, _) => false,
+                ValidationError::RestrictedLicense(_) => true,
                 ValidationError::NoDocumentLanguage => false,
                 ValidationError::NoDocumentTitle => true,
                 ValidationError::MissingAltText(_) => true,


### PR DESCRIPTION
I checked all my system fonts on macOS and only two (pretty arcane) fonts would fail PDF/A export with this change. The bit is not typically set on normal fonts, even commercial ones.