### PR TITLE
Write authors as array in PDF 2.0

### DIFF
--- a/crates/krilla-tests/src/main.rs
+++ b/crates/krilla-tests/src/main.rs
@@ -1077,6 +1077,14 @@ pub fn settings_29() -> SerializeSettings {
     SerializeSettings::default()
 }
 
+pub fn settings_30() -> SerializeSettings {
+    SerializeSettings {
+        configuration: Configuration::new_with_version(PdfVersion::Pdf20),
+        xmp_metadata: true,
+        ..settings_1()
+    }
+}
+
 pub fn metadata_1() -> Metadata {
     Metadata::new()
         .language("en".to_string())

--- a/crates/krilla-tests/src/metadata.rs
+++ b/crates/krilla-tests/src/metadata.rs
@@ -2,15 +2,19 @@ use krilla::metadata::{DateTime, Metadata, PageLayout, TextDirection};
 use krilla::Document;
 use krilla_macros::snapshot;
 
-pub(crate) fn metadata_impl(document: &mut Document) {
-    let date = DateTime::new(2024)
+fn datetime() -> DateTime {
+    DateTime::new(2024)
         .month(11)
         .day(8)
         .hour(22)
         .minute(23)
         .second(18)
         .utc_offset_hour(1)
-        .utc_offset_minute(12);
+        .utc_offset_minute(12)
+}
+
+pub(crate) fn metadata_impl(document: &mut Document) {
+    let date = datetime();
     let metadata = Metadata::new()
         .creation_date(date)
         .subject("A very interesting subject".to_string())
@@ -43,4 +47,12 @@ fn metadata_full(document: &mut Document) {
 #[snapshot(document, settings_5)]
 fn metadata_full_with_xmp(document: &mut Document) {
     metadata_impl(document);
+}
+
+#[snapshot(document, settings_30)]
+fn metadata_pdf_20_author(document: &mut Document) {
+    let metadata = Metadata::new()
+        .authors(vec!["John Doe".to_string(), "Max Mustermann".to_string()])
+        .creation_date(datetime());
+    document.set_metadata(metadata);
 }

--- a/refs/snapshots/metadata_pdf_20_author.txt
+++ b/refs/snapshots/metadata_pdf_20_author.txt
@@ -1,0 +1,75 @@
+%PDF-2.0
+%AAAA
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [2 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Page
+  /Resources <<>>
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 3 0 R
+>>
+endobj
+
+3 0 obj
+<<
+  /Length 0
+>>
+stream
+
+endstream
+endobj
+
+4 0 obj
+<<
+  /ModDate (D:20241108222318+01'12)
+  /CreationDate (D:20241108222318+01'12)
+>>
+endobj
+
+5 0 obj
+<<
+  /Length 984
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:creator><rdf:Seq><rdf:li>John Doe</rdf:li><rdf:li>Max Mustermann</rdf:li></rdf:Seq></dc:creator><xmp:ModifyDate>2024-11-08T22:23:18+01:12</xmp:ModifyDate><xmp:CreateDate>2024-11-08T22:23:18+01:12</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>MwwFglmw0BSz8PWEY/ZfSg==</xmpMM:InstanceID><xmpMM:DocumentID>MwwFglmw0BSz8PWEY/ZfSg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>2.0</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+6 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 5 0 R
+>>
+endobj
+
+xref
+0 7
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000194 00000 n
+0000000246 00000 n
+0000000345 00000 n
+0000001417 00000 n
+trailer
+<<
+  /Size 7
+  /Root 6 0 R
+  /Info 4 0 R
+  /ID [(MwwFglmw0BSz8PWEY/ZfSg==) (MwwFglmw0BSz8PWEY/ZfSg==)]
+>>
+startxref
+1489
+%%EOF


### PR DESCRIPTION
Currently, authors are always folded into a comma-separated single entry in XMP, even though it supports an array. This is a compatibility behavior. The background behind this is that the PDF Document Info dictionary cannot express multiple authors but XMP can. When a document has both present and they do not match, Acrobat will first render the DocInfo author and then the 2nd , 3rd, ... author from the XMP.

In PDF 2.0, the whole document info dictionary has been deprecated in favor of XMP. That means that for these documents, we can disable this compatibility behavior and write an array.