### PR TITLE
Complete artifact types

### DIFF
--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -10,8 +10,8 @@ use krilla::page::PageSettings;
 use krilla::paint::{Fill, Stroke};
 use krilla::surface::Surface;
 use krilla::tagging::{
-    ArtifactType, BBox, ColumnDimensions, ContentTag, NaiveRgbColor, Node, Sides, SpanTag,
-    TagGroup, TagTree,
+    Artifact, ArtifactType, BBox, ColumnDimensions, ContentTag, NaiveRgbColor, Node, Sides,
+    SpanTag, TagGroup, TagTree,
 };
 use krilla::tagging::{ListNumbering, Placement, TableHeaderScope, Tag, TagId, WritingMode};
 use krilla::text::{Font, TextDirection};
@@ -178,7 +178,9 @@ fn tagging_multiple_content_tags(document: &mut Document) {
     let id1 = surface.start_tagged(ContentTag::Span(SpanTag::empty()));
     surface.fill_text_(25.0, "a span");
     surface.end_tagged();
-    let id2 = surface.start_tagged(ContentTag::Artifact(ArtifactType::Header));
+    let id2 = surface.start_tagged(ContentTag::Artifact(Artifact::with_kind(
+        ArtifactType::Header,
+    )));
     surface.fill_text_(50.0, "a header artifact");
     surface.end_tagged();
     let id3 = surface.start_tagged(ContentTag::Other);
@@ -204,7 +206,9 @@ fn tagging_multiple_content_tags(document: &mut Document) {
     surface.pop();
     surface.end_tagged();
 
-    let id6 = surface.start_tagged(ContentTag::Artifact(ArtifactType::Other));
+    let id6 = surface.start_tagged(ContentTag::Artifact(Artifact::with_kind(
+        ArtifactType::Other,
+    )));
     surface.fill_text_(75.0, "a different type of artifact");
     surface.end_tagged();
 
@@ -494,7 +498,7 @@ fn tagging_tag_attributes(document: &mut Document) {
     let mut page = document.start_page();
     let mut surface = page.surface();
 
-    let logo = surface.start_tagged(ContentTag::Artifact(ArtifactType::Other));
+    let logo = surface.start_tagged(ContentTag::Artifact(Artifact::default()));
     surface.outline_text_(100.0, "NASA");
     surface.end_tagged();
 

--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -515,6 +515,22 @@ fn tagging_tag_attributes(document: &mut Document) {
     document.set_tag_tree(tag_tree);
 }
 
+#[snapshot(document)]
+fn tagging_artifact_subtypes(document: &mut Document) {
+    let mut page = document.start_page();
+    let mut surface = page.surface();
+
+    surface.start_tagged(ContentTag::Artifact(Artifact::new(
+        ArtifactType::Watermark,
+        Some(Rect::from_xywh(1.0, 88.0, 21.0, 10.0).unwrap()),
+    )));
+    surface.outline_text_(100.0, "++");
+    surface.end_tagged();
+
+    surface.finish();
+    page.finish();
+}
+
 #[snapshot(document, settings_15)]
 fn tagging_figure_bounds(document: &mut Document) {
     document.set_metadata(Metadata::new().title("Figure".into()).language("en".into()));

--- a/crates/krilla-tests/src/validate.rs
+++ b/crates/krilla-tests/src/validate.rs
@@ -10,7 +10,7 @@ use krilla::num::NormalizedF32;
 use krilla::outline::Outline;
 use krilla::page::Page;
 use krilla::paint::{Fill, FillRule, LinearGradient, SpreadMethod};
-use krilla::tagging::{ArtifactType, ContentTag, SpanTag, TagGroup, TagKind, TagTree};
+use krilla::tagging::{Artifact, ArtifactType, ContentTag, SpanTag, TagGroup, TagKind, TagTree};
 use krilla::tagging::{ListNumbering, TableHeaderScope, Tag};
 use krilla::text::{Font, TextDirection};
 use krilla::text::{GlyphId, KrillaGlyph};
@@ -322,7 +322,9 @@ pub(crate) fn validate_pdf_tagged_full_example(document: &mut Document) {
     );
     surface.end_tagged();
 
-    let id2 = surface.start_tagged(ContentTag::Artifact(ArtifactType::Header));
+    let id2 = surface.start_tagged(ContentTag::Artifact(Artifact::with_kind(
+        ArtifactType::Header,
+    )));
     surface.set_fill(Some(red_fill(1.0)));
     surface.draw_path(&rect_to_path(30.0, 30.0, 70.0, 70.0));
     surface.end_tagged();

--- a/crates/krilla/src/content.rs
+++ b/crates/krilla/src/content.rs
@@ -141,7 +141,10 @@ impl ContentBuilder {
             properties.pairs([(Name(b"MCID"), mcid)]);
         }
 
-        tag.write_properties(sc, properties);
+        // Page height extracted from transform and passed to function to allow
+        // its dependants to flip the y-axis, mirroring Krilla conventions.
+        let page_height = self.root_transform.ty();
+        tag.write_properties(sc, properties, page_height);
     }
 
     pub(crate) fn end_marked_content(&mut self) {

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -131,7 +131,7 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write as _;
 
-use pdf_writer::types::{ArtifactSubtype, RoleMapOpts, StructRole, StructRole2};
+use pdf_writer::types::{RoleMapOpts, StructRole, StructRole2};
 use pdf_writer::writers::{PropertyList, StructElement};
 use pdf_writer::{Chunk, Finish, Name, Ref, Str, TextStr};
 use smallvec::SmallVec;
@@ -154,19 +154,73 @@ pub enum ArtifactType {
     Header,
     /// The footer of the page.
     Footer,
+    /// For text in the back- or foreground of all pages.
+    Watermark,
+    /// Page numbers.
+    PageNumber,
+    /// Numbering artifacts before lines.
+    LineNumber,
+    /// Areas where there formerly was content, but which has been removed.
+    Redaction,
+    /// Bates numbering.
+    Bates,
+    /// Other artifacts arising from pagination not covered by the above variants.
+    PaginationOther,
+    /// Purely cosmetic typographical or design elements.
+    Layout,
     /// Page artifacts, such as for example cut marks or color bars.
     Page,
+    /// The background of a page or a graphical element.
+    Background,
     /// Any other type of artifact (e.g. table strokes).
     Other,
 }
 
 impl ArtifactType {
-    pub(crate) fn requires_properties(&self) -> bool {
+    pub(crate) fn map_pdf_version(self, version: PdfVersion) -> Self {
         match self {
-            ArtifactType::Header => true,
-            ArtifactType::Footer => true,
-            ArtifactType::Page => true,
-            ArtifactType::Other => false,
+            Self::PageNumber | Self::LineNumber | Self::Redaction | Self::Bates
+                if version < PdfVersion::Pdf20 =>
+            {
+                ArtifactType::PaginationOther
+            }
+            Self::Header | Self::Footer | Self::Watermark if version < PdfVersion::Pdf17 => {
+                ArtifactType::PaginationOther
+            }
+            Self::Background if version < PdfVersion::Pdf17 => ArtifactType::Other,
+            _ => self,
+        }
+    }
+
+    pub(crate) fn to_pdf_artifact_type(self) -> Option<pdf_writer::types::ArtifactType> {
+        match self {
+            ArtifactType::Header => Some(pdf_writer::types::ArtifactType::Pagination),
+            ArtifactType::Footer => Some(pdf_writer::types::ArtifactType::Pagination),
+            ArtifactType::Watermark => Some(pdf_writer::types::ArtifactType::Pagination),
+            ArtifactType::PageNumber => Some(pdf_writer::types::ArtifactType::Pagination),
+            ArtifactType::LineNumber => Some(pdf_writer::types::ArtifactType::Pagination),
+            ArtifactType::Redaction => Some(pdf_writer::types::ArtifactType::Pagination),
+            ArtifactType::Bates => Some(pdf_writer::types::ArtifactType::Pagination),
+            ArtifactType::PaginationOther => Some(pdf_writer::types::ArtifactType::Pagination),
+            ArtifactType::Layout => Some(pdf_writer::types::ArtifactType::Layout),
+            ArtifactType::Page => Some(pdf_writer::types::ArtifactType::Page),
+            ArtifactType::Background => Some(pdf_writer::types::ArtifactType::Background),
+            ArtifactType::Other => None,
+        }
+    }
+
+    pub(crate) fn to_pdf_artifact_subtype(
+        self,
+    ) -> Option<pdf_writer::types::ArtifactSubtype<'static>> {
+        match self {
+            ArtifactType::Header => Some(pdf_writer::types::ArtifactSubtype::Header),
+            ArtifactType::Footer => Some(pdf_writer::types::ArtifactSubtype::Footer),
+            ArtifactType::Watermark => Some(pdf_writer::types::ArtifactSubtype::Watermark),
+            ArtifactType::PageNumber => Some(pdf_writer::types::ArtifactSubtype::PageNumber),
+            ArtifactType::LineNumber => Some(pdf_writer::types::ArtifactSubtype::LineNumber),
+            ArtifactType::Redaction => Some(pdf_writer::types::ArtifactSubtype::Redaction),
+            ArtifactType::Bates => Some(pdf_writer::types::ArtifactSubtype::Bates),
+            _ => None,
         }
     }
 }
@@ -214,26 +268,26 @@ impl ContentTag<'_> {
     pub(crate) fn write_properties(&self, sc: &mut SerializeContext, mut properties: PropertyList) {
         match self {
             ContentTag::Artifact(at) => {
+                let at = at.map_pdf_version(sc.serialize_settings().pdf_version());
                 let mut artifact = properties.artifact();
 
-                let artifact_type = match at {
-                    ArtifactType::Header => pdf_writer::types::ArtifactType::Pagination,
-                    ArtifactType::Footer => pdf_writer::types::ArtifactType::Pagination,
-                    ArtifactType::Page => pdf_writer::types::ArtifactType::Page,
+                let Some(artifact_type) = at.to_pdf_artifact_type() else {
                     // This method should only be called with artifacts that actually
                     // require a property.
-                    ArtifactType::Other => unreachable!(),
+                    unreachable!()
                 };
 
                 if sc.serialize_settings().pdf_version() >= PdfVersion::Pdf17 {
-                    if *at == ArtifactType::Header {
+                    if at == ArtifactType::Header {
                         artifact.attached([pdf_writer::types::ArtifactAttachment::Top]);
-                        artifact.subtype(ArtifactSubtype::Header);
                     }
 
-                    if *at == ArtifactType::Footer {
+                    if at == ArtifactType::Footer {
                         artifact.attached([pdf_writer::types::ArtifactAttachment::Bottom]);
-                        artifact.subtype(ArtifactSubtype::Footer);
+                    }
+
+                    if let Some(subtype) = at.to_pdf_artifact_subtype() {
+                        artifact.subtype(subtype);
                     }
                 }
 

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -139,6 +139,7 @@ use smallvec::SmallVec;
 use crate::chunk_container::ChunkContainer;
 use crate::configure::{PdfVersion, ValidationError};
 use crate::error::{KrillaError, KrillaResult};
+use crate::geom::Rect;
 use crate::page::page_root_transform;
 use crate::serialize::SerializeContext;
 
@@ -147,8 +148,47 @@ pub use tag::*;
 pub mod fmt;
 mod tag;
 
+/// An artifact that should not be part of the accessible structure.
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+pub struct Artifact {
+    /// The type of the artifact.
+    pub kind: ArtifactType,
+    /// The bounding box that incloses the artifact's visual content. Required
+    /// for background artifacts.
+    pub bbox: Option<Rect>,
+}
+
+impl Artifact {
+    /// Create a new artifact with a type and an optional BBox.
+    ///
+    /// This will panic if the artifact type is `Background` and no bounding box
+    /// is provided.
+    pub fn new(kind: ArtifactType, bbox: Option<Rect>) -> Self {
+        if kind == ArtifactType::Background && bbox.is_none() {
+            panic!("Background artifacts must have a bounding box");
+        }
+
+        Self { kind, bbox }
+    }
+
+    /// Create a new artifact with a type and no bounding box.
+    pub fn with_kind(kind: ArtifactType) -> Self {
+        Self::new(kind, None)
+    }
+
+    /// Whether the artifacts requires a property list.
+    pub(crate) fn requires_properties(self, pdf_version: PdfVersion) -> bool {
+        self.bbox.is_some()
+            || self
+                .kind
+                .map_pdf_version(pdf_version)
+                .to_pdf_artifact_type()
+                .is_some()
+    }
+}
+
 /// A type of artifact.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
 pub enum ArtifactType {
     /// The header of a page.
     Header,
@@ -172,7 +212,8 @@ pub enum ArtifactType {
     Page,
     /// The background of a page or a graphical element.
     Background,
-    /// Any other type of artifact (e.g. table strokes).
+    /// Any other type of artifact.
+    #[default]
     Other,
 }
 
@@ -243,7 +284,7 @@ pub enum ContentTag<'a> {
     /// Artifacts represent pieces of content that are not really part of the logical structure
     /// of a document and should be excluded in the logical tree. These include for example headers,
     /// footers, page background and similar.
-    Artifact(ArtifactType),
+    Artifact(Artifact),
     /// A content tag that wraps some text with specific properties.
     ///
     /// Spans should not be too long. At most, they should contain a single line of text, but they
@@ -265,33 +306,42 @@ impl ContentTag<'_> {
         }
     }
 
-    pub(crate) fn write_properties(&self, sc: &mut SerializeContext, mut properties: PropertyList) {
+    pub(crate) fn write_properties(
+        &self,
+        sc: &mut SerializeContext,
+        mut properties: PropertyList,
+        page_height: f32,
+    ) {
         match self {
-            ContentTag::Artifact(at) => {
-                let at = at.map_pdf_version(sc.serialize_settings().pdf_version());
-                let mut artifact = properties.artifact();
+            ContentTag::Artifact(artifact) => {
+                let at = artifact
+                    .kind
+                    .map_pdf_version(sc.serialize_settings().pdf_version());
+                let mut artifact_props = properties.artifact();
 
-                let Some(artifact_type) = at.to_pdf_artifact_type() else {
-                    // This method should only be called with artifacts that actually
-                    // require a property.
-                    unreachable!()
-                };
+                if let Some(bbox) = artifact.bbox {
+                    let transform = page_root_transform(page_height);
+                    let actual_rect = bbox.transform(transform).unwrap();
+                    artifact_props.bounding_box(actual_rect.to_pdf_rect());
+                }
 
                 if sc.serialize_settings().pdf_version() >= PdfVersion::Pdf17 {
                     if at == ArtifactType::Header {
-                        artifact.attached([pdf_writer::types::ArtifactAttachment::Top]);
+                        artifact_props.attached([pdf_writer::types::ArtifactAttachment::Top]);
                     }
 
                     if at == ArtifactType::Footer {
-                        artifact.attached([pdf_writer::types::ArtifactAttachment::Bottom]);
+                        artifact_props.attached([pdf_writer::types::ArtifactAttachment::Bottom]);
                     }
 
                     if let Some(subtype) = at.to_pdf_artifact_subtype() {
-                        artifact.subtype(subtype);
+                        artifact_props.subtype(subtype);
                     }
                 }
 
-                artifact.kind(artifact_type);
+                if let Some(artifact_type) = at.to_pdf_artifact_type() {
+                    artifact_props.kind(artifact_type);
+                }
             }
             ContentTag::Span(SpanTag {
                 lang,

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -180,12 +180,8 @@ impl<'a> Surface<'a> {
                 // the API of krilla that conflates artifacts with tagged content,
                 // for the sake of simplicity. But the user of the library does not need to know
                 // about this.
-                ContentTag::Artifact(at) => {
-                    if at
-                        .map_pdf_version(self.sc.serialize_settings().pdf_version())
-                        .to_pdf_artifact_type()
-                        .is_some()
-                    {
+                ContentTag::Artifact(artifact) => {
+                    if artifact.requires_properties(self.sc.serialize_settings().pdf_version()) {
                         self.bd
                             .get_mut()
                             .start_marked_content_with_properties(self.sc, None, tag);

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -181,7 +181,11 @@ impl<'a> Surface<'a> {
                 // for the sake of simplicity. But the user of the library does not need to know
                 // about this.
                 ContentTag::Artifact(at) => {
-                    if at.requires_properties() {
+                    if at
+                        .map_pdf_version(self.sc.serialize_settings().pdf_version())
+                        .to_pdf_artifact_type()
+                        .is_some()
+                    {
                         self.bd
                             .get_mut()
                             .start_marked_content_with_properties(self.sc, None, tag);

--- a/refs/snapshots/tagging_artifact_subtypes.txt
+++ b/refs/snapshots/tagging_artifact_subtypes.txt
@@ -1,0 +1,101 @@
+%PDF-1.7
+%AAAA
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [3 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /ProcSet [/PDF /Text /ImageC /ImageB]
+>>
+endobj
+
+3 0 obj
+<<
+  /Type /Page
+  /Resources 2 0 R
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 4 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Length 470
+>>
+stream
+/Artifact <<
+  /BBox [1 744 22 754]
+  /Subtype /Watermark
+  /Type /Pagination
+>> BDC
+q
+1 0 0 -1 0 842 cm
+0 g
+6.42 92.24 m
+10.4 92.24 l
+10.4 93.66 l
+6.42 93.66 l
+6.42 97.78 l
+4.98 97.78 l
+4.98 93.66 l
+1 93.66 l
+1 92.24 l
+4.98 92.24 l
+4.98 88.1 l
+6.42 88.1 l
+h
+f
+Q
+q
+1 0 0 -1 0 842 cm
+0 g
+17.86 92.24 m
+21.84 92.24 l
+21.84 93.66 l
+17.86 93.66 l
+17.86 97.78 l
+16.42 97.78 l
+16.42 93.66 l
+12.440001 93.66 l
+12.440001 92.24 l
+16.42 92.24 l
+16.42 88.1 l
+17.86 88.1 l
+h
+f
+Q
+EMC
+endstream
+endobj
+
+5 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+>>
+endobj
+
+xref
+0 6
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000142 00000 n
+0000000257 00000 n
+0000000781 00000 n
+trailer
+<<
+  /Size 6
+  /Root 5 0 R
+  /ID [(a1FsThvROvDwMdIVjzpfEw==) (a1FsThvROvDwMdIVjzpfEw==)]
+>>
+startxref
+835
+%%EOF


### PR DESCRIPTION
This commit adds the PDF 1.7 artifact type `Background`, the PDF 1.7 pagination artifact subtype `Watermark`,  and the PDF 2.0 pagination artifact subtypes `PageNum`, `LineNum`, `Redaction`, `Bates`. Finally, the variant `PaginationOther` allows writing a pagination artifact without a subtype.

Because these new variants are not compatible with PDF 1.4, where the mechanism was introduced, a compatibility layer has been introduced.