### PR TITLE
Always create CMap entries in PDF/A-1

### DIFF
--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -315,7 +315,7 @@ impl Validator {
                 ValidationError::TooHighQNestingLevel => true,
                 ValidationError::ContainsPostScript(_) => true,
                 ValidationError::MissingCMYKProfile => true,
-                ValidationError::ContainsNotDefGlyph(_, _, _) => false,
+                ValidationError::ContainsNotDefGlyph(_, _, _) => self.requires_codepoint_mappings(),
                 ValidationError::NoCodepointMapping(_, _, _) => self.requires_codepoint_mappings(),
                 ValidationError::InvalidCodepointMapping(_, _, _, _) => false,
                 ValidationError::UnicodePrivateArea(_, _, _, _) => false,

--- a/crates/krilla/src/text/cid.rs
+++ b/crates/krilla/src/text/cid.rs
@@ -46,10 +46,9 @@ pub(crate) fn write_cmap_entry<G>(
     G: pdf_writer::types::GlyphId + Into<u32> + Copy,
 {
     match entry {
-        None => sc.register_validation_error(ValidationError::InvalidCodepointMapping(
+        None => sc.register_validation_error(ValidationError::NoCodepointMapping(
             font.clone(),
             GlyphId::new(g.into()),
-            None,
             None,
         )),
         Some((text, loc)) => {
@@ -68,13 +67,17 @@ pub(crate) fn write_cmap_entry<G>(
                 }
             }
 
-            if invalid_codepoint {
-                sc.register_validation_error(ValidationError::InvalidCodepointMapping(
+            match invalid_code {
+                Some(c) => sc.register_validation_error(ValidationError::InvalidCodepointMapping(
                     font.clone(),
                     GlyphId::new(g.into()),
-                    invalid_code,
+                    c,
                     *loc,
-                ));
+                )),
+                None if invalid_codepoint => sc.register_validation_error(
+                    ValidationError::NoCodepointMapping(font.clone(), GlyphId::new(g.into()), *loc),
+                ),
+                _ => {}
             }
 
             if let Some(code) = private_unicode {


### PR DESCRIPTION
So far, we interpreted the PDF/A-1 spec to say that there must be a ToUnicode map, but not necessarily that it must contain every character. When testing the Typst test suite against veraPDF with PDF/A-1a, 8 complex shaping tests and 52 math tests failed its [rule 6.3.8-1](https://github.com/veraPDF/veraPDF-validation-profiles/wiki/PDFA-Part-1-rules#rule-638-1), which is defined on the glyph level: They interpret the sentence "The font dictionary shall include a ToUnicode entry whose value is a CMap stream object that maps character codes to Unicode values" to say all glyphs must be mapped.

What neither the standard nor their test suite has is the rule preventing to map to 0, U+FFFE, or U+FEFF. Hence, I have added a new ValidationError variant NoCodepointMapping that means that no codepoint was found whereas InvalidCodepointMapping now only means that we did not like the codepoint we did find. They are enabled for the right standards.

The PR also forbids Tofus in A-1a for the same reason: Because they produce glyphs that are not mapped in the ToUnicode map, they are not allowed. A-1b is unaffected.

With these changes apply, all of the PDFs in Typst test suite that build in PDF/A-1a also pass veraPDF.