### PR TITLE
Raise Missing*AltText error when alt text is empty

### DIFF
--- a/crates/krilla/src/interactive/annotation.rs
+++ b/crates/krilla/src/interactive/annotation.rs
@@ -84,7 +84,9 @@ impl Annotation {
 
         if let Some(alt_text) = &self.alt {
             annotation.contents(TextStr(alt_text));
-        } else {
+        }
+
+        if self.alt.as_ref().is_none_or(String::is_empty) {
             sc.register_validation_error(ValidationError::MissingAnnotationAltText(self.location));
         }
 

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -711,10 +711,11 @@ impl TagGroup {
             *note_id += 1;
         }
 
-        if self.tag.can_have_title() && tag.title().is_none() {
+        if self.tag.can_have_title() && tag.title().is_none_or(str::is_empty) {
             sc.register_validation_error(ValidationError::MissingHeadingTitle);
         }
-        if self.tag.should_have_alt() && tag.alt_text().is_none() {
+
+        if self.tag.should_have_alt() && tag.alt_text().is_none_or(str::is_empty) {
             sc.register_validation_error(ValidationError::MissingAltText(tag.location));
         }
 


### PR DESCRIPTION
This aligns with the [veraPDF rule](https://github.com/veraPDF/veraPDF-validation-profiles/wiki/PDFUA-Part-1-rules#rule-73-1) to check for the presence of alt text