### PR TITLE
Check that features required by UA-1 are available in the current PDF version

### DIFF
--- a/crates/krilla-tests/src/main.rs
+++ b/crates/krilla-tests/src/main.rs
@@ -1181,16 +1181,6 @@ pub fn settings_33() -> SerializeSettings {
     }
 }
 
-pub fn settings_34() -> SerializeSettings {
-    SerializeSettings {
-        configuration: ConfigurationBuilder::new()
-            .with_version(PdfVersion::Pdf14)
-            .finish()
-            .unwrap(),
-        ..settings_1()
-    }
-}
-
 pub fn metadata_1() -> Metadata {
     Metadata::new()
         .language("en".to_string())

--- a/crates/krilla-tests/src/main.rs
+++ b/crates/krilla-tests/src/main.rs
@@ -1170,6 +1170,27 @@ pub fn settings_32() -> SerializeSettings {
     }
 }
 
+pub fn settings_33() -> SerializeSettings {
+    SerializeSettings {
+        configuration: ConfigurationBuilder::new()
+            .with_accessibility_validator(Accessibility::UA1)
+            .with_version(PdfVersion::Pdf14)
+            .finish()
+            .unwrap(),
+        ..settings_1()
+    }
+}
+
+pub fn settings_34() -> SerializeSettings {
+    SerializeSettings {
+        configuration: ConfigurationBuilder::new()
+            .with_version(PdfVersion::Pdf14)
+            .finish()
+            .unwrap(),
+        ..settings_1()
+    }
+}
+
 pub fn metadata_1() -> Metadata {
     Metadata::new()
         .language("en".to_string())
@@ -1183,6 +1204,13 @@ pub fn validation_errors(
         Err(KrillaError::Validation(errors)) => errors.into_iter().map(|(e, _)| e).collect(),
         _ => panic!("expected KrillaError::Validation"),
     }
+}
+
+pub fn metadata_2() -> Metadata {
+    Metadata::new()
+        .language("en".to_string())
+        .title("Test Document".to_string())
+        .creation_date(DateTime::new(2001))
 }
 
 fn main() {

--- a/crates/krilla-tests/src/validate.rs
+++ b/crates/krilla-tests/src/validate.rs
@@ -1,6 +1,7 @@
 use krilla::action::LinkAction;
 use krilla::annotation::{Annotation, LinkAnnotation, Target};
 use krilla::color::{rgb, separation};
+use krilla::configure::validate::VersionedFeature;
 use krilla::configure::ValidationError;
 use krilla::embed::EmbedError;
 use krilla::error::KrillaError;
@@ -19,9 +20,9 @@ use krilla_macros::snapshot;
 use crate::embed::{embedded_file_impl, file_1};
 use crate::{
     blue_fill, cmyk_fill, dummy_text_with_spans, green_fill, load_jpg_image, load_png_image, loc,
-    metadata_1, rect_to_path, red_fill, settings_13, settings_15, settings_19, settings_20,
-    settings_23, settings_24, settings_32, settings_7, settings_8, settings_9,
-    stops_with_2_solid_1, validation_errors, youtube_link, NOTO_SANS,
+    metadata_1, metadata_2, rect_to_path, red_fill, settings_13, settings_15, settings_19,
+    settings_20, settings_23, settings_24, settings_32, settings_33, settings_34, settings_7,
+    settings_8, settings_9, stops_with_2_solid_1, validation_errors, youtube_link, NOTO_SANS,
 };
 use crate::{Document, SerializeSettings};
 
@@ -964,6 +965,39 @@ fn validate_inconsistent_separation_fallback() {
     );
 }
 
+fn validate_pdf14_ua1_header_footer_artifact_subtypes() {
+    let mut document = Document::new_with(settings_33());
+    let mut page = document.start_page();
+    let mut surface = page.surface();
+
+    let id = surface.start_tagged(ContentTag::Artifact(Artifact::with_kind(
+        ArtifactType::Header,
+    )));
+    surface.set_fill(Some(red_fill(1.0)));
+    surface.draw_path(&rect_to_path(30.0, 30.0, 70.0, 70.0));
+    surface.end_tagged();
+
+    surface.finish();
+    page.finish();
+
+    let mut tag_tree = TagTree::new();
+    tag_tree.push(id);
+    document.set_tag_tree(tag_tree);
+
+    document.set_metadata(metadata_2());
+
+    let outline = Outline::new();
+    document.set_outline(outline);
+
+    assert_eq!(
+        validation_errors(document.finish()),
+        vec![ValidationError::RequiresNewerPdfVersion(
+            VersionedFeature::HeaderFooterArtifactSubtypes,
+            None
+        )]
+    );
+}
+
 #[snapshot(document)]
 fn no_validators_embedded_file_no_af(d: &mut Document) {
     // Embedded files are written but no AF (associated files) entry is
@@ -1041,4 +1075,109 @@ fn validate_multi_validator_pdf_a3b_pdf_ua1_full_example(document: &mut Document
     document.set_metadata(metadata);
 
     document.set_outline(Outline::new());
+}
+
+#[test]
+fn validate_pdf14_ua1_structure_order_tabbing() {
+    let mut document = Document::new_with(settings_33());
+    let mut page = document.start_page();
+
+    let annot = page.add_tagged_annotation(Annotation::new_link(
+        LinkAnnotation::new(
+            Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
+            Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
+        ),
+        Some("Link to YouTube".to_string()),
+    ));
+
+    page.finish();
+
+    let mut tag_tree = TagTree::new();
+    tag_tree.push(annot);
+    document.set_tag_tree(tag_tree);
+
+    document.set_metadata(metadata_2());
+
+    let outline = Outline::new();
+    document.set_outline(outline);
+
+    assert_eq!(
+        validation_errors(document.finish()),
+        vec![ValidationError::RequiresNewerPdfVersion(
+            VersionedFeature::StructureOrderTabbing,
+            None
+        )]
+    );
+}
+
+#[test]
+fn validate_pdf14_ua1_table_header_scope() {
+    let mut document = Document::new_with(settings_33());
+    let mut page = document.start_page();
+    let mut surface = page.surface();
+
+    let font_data = NOTO_SANS.clone();
+    let font = Font::new(font_data, 0).unwrap();
+
+    let text_id = surface.start_tagged(ContentTag::Span(SpanTag::empty()));
+    surface.draw_text(
+        Point::from_xy(0.0, 100.0),
+        font,
+        20.0,
+        "header",
+        false,
+        TextDirection::Auto,
+    );
+    surface.end_tagged();
+
+    surface.finish();
+    page.finish();
+
+    let mut row = TagGroup::new(Tag::TR);
+    let mut th = TagGroup::new(Tag::TH(TableHeaderScope::Row));
+    th.push(text_id);
+    row.push(th);
+
+    let mut table = TagGroup::new(Tag::Table);
+    table.push(row);
+
+    let mut tag_tree = TagTree::new();
+    tag_tree.push(table);
+    document.set_tag_tree(tag_tree);
+
+    document.set_metadata(metadata_2());
+
+    let outline = Outline::new();
+    document.set_outline(outline);
+
+    assert_eq!(
+        validation_errors(document.finish()),
+        vec![ValidationError::RequiresNewerPdfVersion(
+            VersionedFeature::TableHeaderScope,
+            None
+        )]
+    );
+}
+
+#[test]
+fn validate_pdf14_tagged_annotation_no_ua() {
+    // tagging + annotation + PDF 1.4 without UA validator must not fail
+    let mut document = Document::new_with(settings_34());
+    let mut page = document.start_page();
+
+    let annot = page.add_tagged_annotation(Annotation::new_link(
+        LinkAnnotation::new(
+            Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
+            Target::Action(LinkAction::new("https://www.youtube.com".to_string()).into()),
+        ),
+        None,
+    ));
+
+    page.finish();
+
+    let mut tag_tree = TagTree::new();
+    tag_tree.push(annot);
+    document.set_tag_tree(tag_tree);
+
+    assert!(document.finish().is_ok());
 }

--- a/crates/krilla-tests/src/validate.rs
+++ b/crates/krilla-tests/src/validate.rs
@@ -1156,7 +1156,8 @@ fn validate_pdf14_ua1_table_header_scope() {
 
 #[test]
 fn validate_pdf14_tagged_annotation_no_ua() {
-    // tagging + annotation + PDF 1.4 without UA validator must not fail
+    // Ensure tagging + annotation + PDF 1.4 without UA validator doesn't
+    // fail (see https://github.com/LaurenzV/krilla/pull/278#discussion_r3213542007).
     let mut document = Document::new_with(settings_17());
     let mut page = document.start_page();
 

--- a/crates/krilla-tests/src/validate.rs
+++ b/crates/krilla-tests/src/validate.rs
@@ -18,7 +18,12 @@ use krilla::text::{GlyphId, KrillaGlyph};
 use krilla_macros::snapshot;
 
 use crate::embed::{embedded_file_impl, file_1};
-use crate::{blue_fill, cmyk_fill, dummy_text_with_spans, green_fill, load_jpg_image, load_png_image, loc, metadata_1, metadata_2, rect_to_path, red_fill, settings_13, settings_15, settings_17, settings_19, settings_20, settings_23, settings_24, settings_32, settings_33, settings_7, settings_8, settings_9, stops_with_2_solid_1, validation_errors, youtube_link, NOTO_SANS};
+use crate::{
+    blue_fill, cmyk_fill, dummy_text_with_spans, green_fill, load_jpg_image, load_png_image, loc,
+    metadata_1, metadata_2, rect_to_path, red_fill, settings_13, settings_15, settings_17,
+    settings_19, settings_20, settings_23, settings_24, settings_32, settings_33, settings_7,
+    settings_8, settings_9, stops_with_2_solid_1, validation_errors, youtube_link, NOTO_SANS,
+};
 use crate::{Document, SerializeSettings};
 
 fn pdfa_document() -> Document {

--- a/crates/krilla-tests/src/validate.rs
+++ b/crates/krilla-tests/src/validate.rs
@@ -18,12 +18,7 @@ use krilla::text::{GlyphId, KrillaGlyph};
 use krilla_macros::snapshot;
 
 use crate::embed::{embedded_file_impl, file_1};
-use crate::{
-    blue_fill, cmyk_fill, dummy_text_with_spans, green_fill, load_jpg_image, load_png_image, loc,
-    metadata_1, metadata_2, rect_to_path, red_fill, settings_13, settings_15, settings_19,
-    settings_20, settings_23, settings_24, settings_32, settings_33, settings_34, settings_7,
-    settings_8, settings_9, stops_with_2_solid_1, validation_errors, youtube_link, NOTO_SANS,
-};
+use crate::{blue_fill, cmyk_fill, dummy_text_with_spans, green_fill, load_jpg_image, load_png_image, loc, metadata_1, metadata_2, rect_to_path, red_fill, settings_13, settings_15, settings_17, settings_19, settings_20, settings_23, settings_24, settings_32, settings_33, settings_7, settings_8, settings_9, stops_with_2_solid_1, validation_errors, youtube_link, NOTO_SANS};
 use crate::{Document, SerializeSettings};
 
 fn pdfa_document() -> Document {
@@ -1162,7 +1157,7 @@ fn validate_pdf14_ua1_table_header_scope() {
 #[test]
 fn validate_pdf14_tagged_annotation_no_ua() {
     // tagging + annotation + PDF 1.4 without UA validator must not fail
-    let mut document = Document::new_with(settings_34());
+    let mut document = Document::new_with(settings_17());
     let mut page = document.start_page();
 
     let annot = page.add_tagged_annotation(Annotation::new_link(

--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -140,6 +140,30 @@ pub enum ValidationError {
     /// This is currently forbidden in validated export because we cannot manually verify
     /// whether the file actually fulfills all the criteria for the export mode.
     EmbeddedPDF(Option<Location>),
+    /// A feature only available in a later PDF version was required.
+    RequiresNewerPdfVersion(VersionedFeature, Option<Location>),
+}
+
+/// Features that may require a later PDF version than the current one.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VersionedFeature {
+    /// Tabbing through the document according to the structure order.
+    StructureOrderTabbing,
+    /// Header and footer artifact subtypes.
+    HeaderFooterArtifactSubtypes,
+    /// Scope attribute for table header cells.
+    TableHeaderScope,
+}
+
+impl VersionedFeature {
+    /// Get the minimum PDF version required for this feature.
+    pub fn minimum_pdf_version(&self) -> PdfVersion {
+        match self {
+            VersionedFeature::StructureOrderTabbing => PdfVersion::Pdf15,
+            VersionedFeature::HeaderFooterArtifactSubtypes => PdfVersion::Pdf17,
+            VersionedFeature::TableHeaderScope => PdfVersion::Pdf15,
+        }
+    }
 }
 
 /// Collection of validators with at most one validator for each standard.
@@ -506,7 +530,13 @@ impl Archival {
                 | ValidationError::NoDocumentTitle
                 | ValidationError::MissingHeadingTitle
                 | ValidationError::MissingDocumentOutline
-                | ValidationError::EmbeddedFile(_, _),
+                | ValidationError::EmbeddedFile(_, _)
+                | ValidationError::RequiresNewerPdfVersion(
+                    VersionedFeature::HeaderFooterArtifactSubtypes
+                    | VersionedFeature::StructureOrderTabbing
+                    | VersionedFeature::TableHeaderScope,
+                    _,
+                ),
             ) => false,
             // Forbidden under PDF/A-1a but allowed under PDF/A-1b.
             (
@@ -544,7 +574,13 @@ impl Archival {
                 | ValidationError::NoDocumentTitle
                 | ValidationError::Transparency(_)
                 | ValidationError::MissingHeadingTitle
-                | ValidationError::MissingDocumentOutline,
+                | ValidationError::MissingDocumentOutline
+                | ValidationError::RequiresNewerPdfVersion(
+                    VersionedFeature::HeaderFooterArtifactSubtypes
+                    | VersionedFeature::StructureOrderTabbing
+                    | VersionedFeature::TableHeaderScope,
+                    _,
+                ),
             ) => false,
             // Forbidden under PDF/A-2 but allowed under PDF/A-3.
             (
@@ -615,7 +651,13 @@ impl Archival {
                     EmbedError::MissingDate | EmbedError::MissingMimeType,
                     _,
                 )
-                | ValidationError::MissingTagging,
+                | ValidationError::MissingTagging
+                | ValidationError::RequiresNewerPdfVersion(
+                    VersionedFeature::HeaderFooterArtifactSubtypes
+                    | VersionedFeature::StructureOrderTabbing
+                    | VersionedFeature::TableHeaderScope,
+                    _,
+                ),
             ) => false,
             // Forbidden under PDF/A-4 but allowed under other PDF/A-4 profiles.
             (
@@ -1033,7 +1075,13 @@ impl Accessibility {
                 | ValidationError::MissingAnnotationAltText(_)
                 | ValidationError::EmbeddedFile(EmbedError::MissingDescription, _)
                 | ValidationError::MissingTagging
-                | ValidationError::EmbeddedPDF(_),
+                | ValidationError::EmbeddedPDF(_)
+                | ValidationError::RequiresNewerPdfVersion(
+                    VersionedFeature::HeaderFooterArtifactSubtypes
+                    | VersionedFeature::StructureOrderTabbing
+                    | VersionedFeature::TableHeaderScope,
+                    _,
+                ),
             ) => true,
             (
                 Self::UA1,

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -826,7 +826,8 @@ impl TagGroup {
             sc.register_validation_error(ValidationError::MissingAltText(tag.location));
         }
 
-        // TODO: validate TH-outside-THead structure for PDF < 1.5
+        // TODO: Once we have a generalized mechanism for validating tag trees,
+        // validate TH-outside-THead structure for PDF < 1.5.
 
         for attr in tag.attrs.iter() {
             let Attr::Struct(attr) = attr else {

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -137,6 +137,7 @@ use pdf_writer::{Chunk, Finish, Name, Ref, Str, TextStr};
 use smallvec::SmallVec;
 
 use crate::chunk_container::ChunkContainer;
+use crate::configure::validate::VersionedFeature;
 use crate::configure::{PdfVersion, ValidationError};
 use crate::error::{KrillaError, KrillaResult};
 use crate::geom::Rect;
@@ -825,6 +826,8 @@ impl TagGroup {
             sc.register_validation_error(ValidationError::MissingAltText(tag.location));
         }
 
+        // TODO: validate TH-outside-THead structure for PDF < 1.5
+
         for attr in tag.attrs.iter() {
             let Attr::Struct(attr) = attr else {
                 continue;
@@ -889,6 +892,12 @@ impl TagGroup {
                 TableAttr::HeaderScope(scope) => {
                     if pdf_version >= PdfVersion::Pdf15 {
                         table_attributes.scope(scope.to_pdf());
+                    } else if scope == &TableHeaderScope::Row {
+                        // Without `Scope`, the correct cell to point to is ambiguous.
+                        sc.register_validation_error(ValidationError::RequiresNewerPdfVersion(
+                            VersionedFeature::TableHeaderScope,
+                            tag.location,
+                        ));
                     }
                 }
                 TableAttr::CellHeaders(headers) => {

--- a/crates/krilla/src/page.rs
+++ b/crates/krilla/src/page.rs
@@ -9,7 +9,8 @@ use pdf_writer::writers::NumberTree;
 use pdf_writer::{Chunk, Finish, Ref, TextStr};
 
 use crate::chunk_container::ChunkContainer;
-use crate::configure::PdfVersion;
+use crate::configure::validate::VersionedFeature;
+use crate::configure::{PdfVersion, ValidationError};
 use crate::content::ContentBuilder;
 use crate::error::KrillaResult;
 use crate::geom::{Rect, Size, Transform};
@@ -445,11 +446,15 @@ impl InternalPage {
         }
 
         // Only required for PDF/UA, but might as well always set it.
-        if !self.annotations.is_empty()
-            && sc.serialize_settings().enable_tagging
-            && sc.serialize_settings().pdf_version() >= PdfVersion::Pdf15
-        {
-            page.tab_order(TabOrder::StructureOrder);
+        if !self.annotations.is_empty() && sc.serialize_settings().enable_tagging {
+            if sc.serialize_settings().pdf_version() >= PdfVersion::Pdf15 {
+                page.tab_order(TabOrder::StructureOrder);
+            } else {
+                sc.register_validation_error(ValidationError::RequiresNewerPdfVersion(
+                    VersionedFeature::StructureOrderTabbing,
+                    sc.location,
+                ));
+            }
         }
 
         page.parent(sc.page_tree_ref());

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -8,6 +8,8 @@ use std::num::NonZeroU64;
 
 use crate::chunk_container::ChunkContainer;
 use crate::color::rgb;
+use crate::configure::validate::VersionedFeature;
+use crate::configure::ValidationError;
 use crate::content::ContentBuilder;
 use crate::geom::Path;
 #[cfg(any(feature = "raster-images", feature = "pdf"))]
@@ -28,7 +30,7 @@ use crate::paint::{InnerPaint, Paint};
 use crate::pdf::PdfDocument;
 use crate::serialize::SerializeContext;
 use crate::stream::{Stream, StreamBuilder};
-use crate::tagging::SpanTag;
+use crate::tagging::{ArtifactType, SpanTag};
 use crate::text::Font;
 use crate::text::{draw_glyph, Glyph};
 #[cfg(feature = "simple-text")]
@@ -181,6 +183,15 @@ impl<'a> Surface<'a> {
                 // for the sake of simplicity. But the user of the library does not need to know
                 // about this.
                 ContentTag::Artifact(artifact) => {
+                    if matches!(artifact.kind, ArtifactType::Header | ArtifactType::Footer) {
+                        self.sc.register_validation_error(
+                            ValidationError::RequiresNewerPdfVersion(
+                                VersionedFeature::HeaderFooterArtifactSubtypes,
+                                self.sc.location,
+                            ),
+                        );
+                    }
+
                     if artifact.requires_properties(self.sc.serialize_settings().pdf_version()) {
                         self.bd
                             .get_mut()


### PR DESCRIPTION
This PR checks that three features are available by the current PDF version in circumstances in which PDF/UA-1 requires them. If they are needed but unavailable, a validation error is raised.

An earlier implementation of this PR just forbid export to these lower versions entirely.