### PR TITLE
Check page settings size upon construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Documentation](https://docs.rs/krilla/badge.svg)](https://docs.rs/krilla)
 
 `krilla` is a high-level Rust crate that allows for the creation of PDF files. It builds
-on top of the [pdf-writer](https://github.com/typst/pdf-writer) crate, 
-but abstracts away all complexities that are involved in creating a PDF file, 
+on top of the [pdf-writer](https://github.com/typst/pdf-writer) crate,
+but abstracts away all complexities that are involved in creating a PDF file,
 instead providing an interface with high-level primitives, such
 as fills, strokes, gradient, glyphs and images which can be used and combined easily
 without having to worry about low-level details.
@@ -42,31 +42,31 @@ of the complexity of the PDF format and instead provides high-level primitives f
 creating PDF files. However from a document-creation perspective, this crate is still
 very low-level: It does not provide functionality like text layouting, creation of tables,
 page breaking, inserting headers/footers, etc. This kind of functionality is strictly out of scope for
-`krilla`. 
+`krilla`.
 
 `krilla`'s main "target group" is libraries that have some kind of intermediate representation
-of layouted content (whether it be from HTML or other input sources), and want to easily 
+of layouted content (whether it be from HTML or other input sources), and want to easily
 translate this representation into a PDF file. If this is your use case, then `krilla` is probably
-a very suitable, if not the most suitable choice for you. 
+a very suitable, if not the most suitable choice for you.
 
 If not, depending on what exactly you want to do, there are other Rust crates you can use:
 
 - Creating PDF files with very low-level access to the resulting file: [pdf-writer](https://github.com/typst/pdf-writer).
-- Creating documents requiring high-level functionality like automatic text layouting, 
+- Creating documents requiring high-level functionality like automatic text layouting,
 page breaking, inserting headers and footers: [typst](https://github.com/typst/typst/).
 - Reading existing PDF documents and manipulating them in a certain way: [pdf-rs](https://github.com/pdf-rs/pdf).
 
 Also worth mentioning is [printpdf](https://github.com/fschutt/printpdf) which operates at a similar level of abstraction as `krilla`, but is based on `lopdf` has a greater focus on creating print-friendly PDFs.
 
 The PDF specification is *huge* and supports tons of features with a lot of customization, including
-complex color spaces and shadings. The goal of `krilla` is not to expose high-level bindings 
+complex color spaces and shadings. The goal of `krilla` is not to expose high-level bindings
 for all functionality, but instead expose only a relevant subset of it. Implementing features like encryption or digital signatures, as well as many other PDF features, are (for now) out-of-scope for this crate.
 
 ## Testing
 Testing is a major pain point for most PDF-creation libraries. The reason is that it is very hard to do:
-It is very easy to accidentally create invalid PDF files, and just testing PDF files in one 
-PDF viewer is not enough to be confident about its correctness. The reason for this 
-is that PDF viewers are often tolerant in what they accept, meaning that it is possible 
+It is very easy to accidentally create invalid PDF files, and just testing PDF files in one
+PDF viewer is not enough to be confident about its correctness. The reason for this
+is that PDF viewers are often tolerant in what they accept, meaning that it is possible
 that a PDF just happens to show up fine in one viewer you tested, but fails in all other ones.
 
 **Because of this, ensuring proper testing has been one of my main priorities when building this crate,
@@ -81,7 +81,7 @@ regressions in the actual output of our PDFs. These snippets are also tested aga
 
 #### Unit tests
 As mentioned above, checking one PDF viewer for correct output is not enough. Because of this, our visual
-regression tests are run against **6 distinct PDF viewers** (although only 5 are run in CI) to ensure that basic 
+regression tests are run against **6 distinct PDF viewers** (although only 5 are run in CI) to ensure that basic
 `krilla` features are displayed correctly in all major viewers. The current selection of viewers includes:
 - ghostscript
 - mupdf
@@ -101,7 +101,7 @@ all tests have been opened at least once with Acrobat to ensure that no errors a
 Finally, we also have visual integration tests to test distinct features as well as combinations of them
 (like for example gradients with transforms). We use the `resvg` test suite for that, which conveniently
 also allows us to automatically test the accuracy of the SVG conversion of `krilla-svg`. Those tests are
-only run against one viewer (in most cases `pdfium`), as it would be pretty wasteful to save reference images for all of them. 
+only run against one viewer (in most cases `pdfium`), as it would be pretty wasteful to save reference images for all of them.
 
 *Currently, we have over 1500 such tests*, and although they mostly focus on
 testing adherence to the SVG specification, they indirectly also test various interactions of `krilla`-specific
@@ -134,7 +134,7 @@ let font = {
 };
 
 // Add a new page with dimensions 200x200.
-let mut page = document.start_page_with(PageSettings::new(200.0, 200.0));
+let mut page = document.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
 // Get the surface of the page.
 let mut surface = page.surface();
 // Draw some text.
@@ -167,7 +167,7 @@ surface.finish();
 page.finish();
 
 // Start a new page.
-let mut page = document.start_page_with(PageSettings::new(200.0, 200.0));
+let mut page = document.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
 // Create the triangle.
 let triangle = {
     let mut pb = PathBuilder::new();

--- a/crates/krilla-macros/src/lib.rs
+++ b/crates/krilla-macros/src/lib.rs
@@ -68,7 +68,7 @@ pub fn snapshot(attr: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #common
                 let settings = crate::#serialize_settings();
-                let page_settings = PageSettings::new(200.0, 200.0);
+                let page_settings = PageSettings::from_wh(200.0, 200.0).unwrap();
                 let mut d = Document::new_with(settings);
                 let mut page = d.start_page_with(page_settings);
                 #impl_ident(&mut page);
@@ -211,7 +211,7 @@ pub fn visreg(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! {
             let settings = crate::#serialize_settings();
             let mut d = Document::new_with(settings);
-            let page_settings = PageSettings::new(200.0, 200.0).with_media_box(None);
+            let page_settings = PageSettings::from_wh(200.0, 200.0).unwrap().with_media_box(None);
             let mut page = d.start_page_with(page_settings);
             let mut surface = page.surface();
             #impl_ident(&mut surface);

--- a/crates/krilla-svg/examples/svg.rs
+++ b/crates/krilla-svg/examples/svg.rs
@@ -31,7 +31,7 @@ fn main() {
 
     let svg_size = Size::from_wh(svg_tree.size().width(), svg_tree.size().height()).unwrap();
     // Start a new page, with the same dimensions as the SVG.
-    let mut page = document.start_page_with(PageSettings::new(svg_size.width(), svg_size.height()));
+    let mut page = document.start_page_with(PageSettings::new(svg_size));
     let mut surface = page.surface();
     // Draw the SVG.
     surface.draw_svg(&svg_tree, svg_size, SvgSettings::default());

--- a/crates/krilla-tests/src/annotation.rs
+++ b/crates/krilla-tests/src/annotation.rs
@@ -1,6 +1,6 @@
 use krilla::annotation::LinkBorder;
 use krilla::destination::XyzDestination;
-use krilla::geom::{Point, Quadrilateral, Rect};
+use krilla::geom::{Point, Quadrilateral, Rect, Size};
 use krilla::page::{Page, PageSettings};
 use krilla::Document;
 use krilla_macros::{snapshot, visreg};
@@ -64,7 +64,7 @@ fn annotation_with_quad_points(page: &mut Page) {
 #[should_panic]
 fn annotation_to_invalid_destination() {
     let mut d = Document::new_with(settings_1());
-    let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
+    let mut page = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     page.add_annotation(
         LinkAnnotation::new(
             Rect::from_xywh(50.0, 50.0, 100.0, 100.0).unwrap(),
@@ -79,7 +79,7 @@ fn annotation_to_invalid_destination() {
 
 #[snapshot(document)]
 fn annotation_to_destination(d: &mut Document) {
-    let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
+    let mut page = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     page.add_annotation(
         LinkAnnotation::new(
             Rect::from_xywh(50.0, 0.0, 100.0, 100.0).unwrap(),
@@ -94,7 +94,7 @@ fn annotation_to_destination(d: &mut Document) {
     surface.finish();
     page.finish();
 
-    let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
+    let mut page = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     page.add_annotation(
         LinkAnnotation::new(
             Rect::from_xywh(50.0, 100.0, 100.0, 100.0).unwrap(),
@@ -115,7 +115,7 @@ fn annotation_to_embedded_pdf_page(document: &mut Document) {
     let pdf = load_pdf("page_media_box_bottom_right.pdf");
     document.embed_pdf_pages(&pdf, &[0]);
 
-    let mut page = document.start_page_with(PageSettings::new(200.0, 200.0));
+    let mut page = document.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     page.add_annotation(
         LinkAnnotation::new(
             Rect::from_xywh(0.0, 0.0, 200.0, 200.0).unwrap(),

--- a/crates/krilla-tests/src/main.rs
+++ b/crates/krilla-tests/src/main.rs
@@ -668,7 +668,8 @@ pub fn all_glyphs_to_pdf(
     let units_per_em = metrics.units_per_em as f32;
     let mut cur_point = 0;
 
-    let mut builder = d.start_page_with(PageSettings::new(width as f32, height as f32));
+    let mut builder =
+        d.start_page_with(PageSettings::from_wh(width as f32, height as f32).unwrap());
     let mut surface = builder.surface();
 
     let colors = if color_cycling {
@@ -850,11 +851,12 @@ pub(crate) fn svg_impl(name: &str, renderer: Renderer, ignore_renderer: bool) {
     )
     .unwrap();
 
-    let mut page = d.start_page_with(PageSettings::new(tree.size().width(), tree.size().height()));
+    let size = krilla::geom::Size::from_wh(tree.size().width(), tree.size().height()).unwrap();
+    let mut page = d.start_page_with(PageSettings::new(size));
     let mut surface = page.surface();
     surface.draw_svg(
         &tree,
-        krilla::geom::Size::from_wh(tree.size().width(), tree.size().height()).unwrap(),
+        size,
         SvgSettings {
             embed_text: true,
             filter_scale: 2.0,

--- a/crates/krilla-tests/src/outline.rs
+++ b/crates/krilla-tests/src/outline.rs
@@ -13,7 +13,7 @@ fn outline_simple(d: &mut Document) {
     for (index, fill) in fills.into_iter().enumerate() {
         let factor = index as f32 * 50.0;
         let path = rect_to_path(factor, factor, 100.0 + factor, 100.0 + factor);
-        let mut page = d.start_page_with(PageSettings::new(200.0, 200.0));
+        let mut page = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
         let mut surface = page.surface();
         surface.set_fill(Some(fill));
         surface.draw_path(&path);

--- a/crates/krilla-tests/src/page.rs
+++ b/crates/krilla-tests/src/page.rs
@@ -9,8 +9,11 @@ use tiny_skia_path::PathBuilder;
 use crate::{blue_fill, green_fill, purple_fill, rect_to_path, red_fill};
 
 fn media_box_impl(d: &mut Document, media_box: Rect) {
-    let mut page =
-        d.start_page_with(PageSettings::new(200.0, 200.0).with_media_box(Some(media_box)));
+    let mut page = d.start_page_with(
+        PageSettings::from_wh(200.0, 200.0)
+            .unwrap()
+            .with_media_box(Some(media_box)),
+    );
     let mut surface = page.surface();
     surface.set_fill(Some(red_fill(0.5)));
     surface.draw_path(&rect_to_path(0.0, 0.0, 100.0, 100.0));
@@ -24,14 +27,16 @@ fn media_box_impl(d: &mut Document, media_box: Rect) {
 
 #[snapshot(document)]
 fn page_label(d: &mut Document) {
-    d.start_page_with(PageSettings::new(200.0, 200.0));
-    d.start_page_with(PageSettings::new(250.0, 200.0));
+    d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
+    d.start_page_with(PageSettings::from_wh(250.0, 200.0).unwrap());
 
-    let settings = PageSettings::new(250.0, 200.0).with_page_label(PageLabel::new(
-        Some(NumberingStyle::LowerRoman),
-        None,
-        NonZeroUsize::new(2),
-    ));
+    let settings = PageSettings::from_wh(250.0, 200.0)
+        .unwrap()
+        .with_page_label(PageLabel::new(
+            Some(NumberingStyle::LowerRoman),
+            None,
+            NonZeroUsize::new(2),
+        ));
 
     d.start_page_with(settings);
 }
@@ -39,7 +44,8 @@ fn page_label(d: &mut Document) {
 #[snapshot(document)]
 fn page_with_crop_bleeding_trim_art_boxes(d: &mut Document) {
     // Create page settings with different boxes
-    let page_settings = PageSettings::new(200.0, 200.0)
+    let page_settings = PageSettings::from_wh(200.0, 200.0)
+        .unwrap()
         .with_media_box(Some(Rect::from_xywh(0.0, 0.0, 200.0, 200.0).unwrap()))
         .with_crop_box(Some(Rect::from_xywh(10.0, 10.0, 180.0, 180.0).unwrap()))
         .with_bleed_box(Some(Rect::from_xywh(20.0, 20.0, 160.0, 160.0).unwrap()))

--- a/crates/krilla-tests/src/pdf.rs
+++ b/crates/krilla-tests/src/pdf.rs
@@ -177,7 +177,7 @@ fn pdf_embedded_as_xobject_basic(page: &mut Page) {
 
 #[visreg(document)]
 fn pdf_embedded_as_xobject_different_sizes(document: &mut Document) {
-    let mut page = document.start_page_with(PageSettings::new(600.0, 600.0));
+    let mut page = document.start_page_with(PageSettings::from_wh(600.0, 600.0).unwrap());
     let mut surface = page.surface();
 
     let sizes = [(50.0, 50.0), (150.0, 150.0), (300.0, 150.0), (200.0, 400.0)];
@@ -201,7 +201,7 @@ fn pdf_embedded_as_xobject_multiple(document: &mut Document) {
     let pdf2 = load_pdf("pdftc_100k_1894.pdf");
     let pdf3 = load_pdf("page_media_box_bottom_right.pdf");
 
-    let mut page1 = document.start_page_with(PageSettings::new(600.0, 800.0));
+    let mut page1 = document.start_page_with(PageSettings::from_wh(600.0, 800.0).unwrap());
     let mut surface = page1.surface();
 
     surface.push_transform(&Transform::from_translate(10.0, 15.0));
@@ -219,7 +219,7 @@ fn pdf_embedded_as_xobject_multiple(document: &mut Document) {
     surface.finish();
     page1.finish();
 
-    let mut page2 = document.start_page_with(PageSettings::new(500.0, 500.0));
+    let mut page2 = document.start_page_with(PageSettings::from_wh(500.0, 500.0).unwrap());
     let mut surface = page2.surface();
 
     surface.draw_pdf_page(&pdf2, Size::from_wh(250.0, 250.8).unwrap(), 3);

--- a/crates/krilla/examples/basic.rs
+++ b/crates/krilla/examples/basic.rs
@@ -25,7 +25,7 @@ fn main() {
     };
 
     // Add a new page with dimensions 200x200.
-    let mut page = document.start_page_with(PageSettings::new(200.0, 200.0));
+    let mut page = document.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     // Get the surface of the page.
     let mut surface = page.surface();
     // Draw some text.
@@ -58,7 +58,7 @@ fn main() {
     page.finish();
 
     // Start a new page.
-    let mut page = document.start_page_with(PageSettings::new(200.0, 200.0));
+    let mut page = document.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     // Create the triangle.
     let triangle = {
         let mut pb = PathBuilder::new();

--- a/crates/krilla/examples/empty_document.rs
+++ b/crates/krilla/examples/empty_document.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut document = Document::new();
     // We can now successively add new pages by calling `start_page`, or `start_page_with`
     // if we want to pass custom page settings.
-    let page = document.start_page_with(PageSettings::new(300.0, 600.0));
+    let page = document.start_page_with(PageSettings::from_wh(300.0, 600.0).unwrap());
     page.finish();
 
     // Create the PDF

--- a/crates/krilla/examples/parley.rs
+++ b/crates/krilla/examples/parley.rs
@@ -65,7 +65,7 @@ fn main() {
 
     // The usual page setup.
     let mut document = Document::new();
-    let mut page = document.start_page_with(PageSettings::new(200.0, 300.0));
+    let mut page = document.start_page_with(PageSettings::from_wh(200.0, 300.0).unwrap());
     let mut surface = page.surface();
 
     for line in layout.lines() {

--- a/crates/krilla/examples/simple_text.rs
+++ b/crates/krilla/examples/simple_text.rs
@@ -27,7 +27,7 @@ pub(crate) static ASSETS_PATH: LazyLock<PathBuf> = LazyLock::new(|| WORKSPACE_PA
 fn main() {
     // The usual page setup.
     let mut document = Document::new();
-    let mut page = document.start_page_with(PageSettings::new(600.0, 280.0));
+    let mut page = document.start_page_with(PageSettings::from_wh(600.0, 280.0).unwrap());
     let mut surface = page.surface();
 
     let noto_font = Font::new(

--- a/crates/krilla/examples/stream_builder.rs
+++ b/crates/krilla/examples/stream_builder.rs
@@ -12,7 +12,7 @@ use krilla::Document;
 
 fn main() {
     let mut document = Document::new();
-    let mut page = document.start_page_with(PageSettings::new(200.0, 200.0));
+    let mut page = document.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     let mut surface = page.surface();
 
     // We want to define a pattern with a red rectangle on the top-left and a

--- a/crates/krilla/src/lib.rs
+++ b/crates/krilla/src/lib.rs
@@ -44,7 +44,7 @@ let font = {
 };
 
 // Add a new page with dimensions 200x200.
-let mut page = document.start_page_with(PageSettings::new(200.0, 200.0));
+let mut page = document.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
 // Get the surface of the page.
 let mut surface = page.surface();
 // Draw some text.
@@ -77,7 +77,7 @@ surface.finish();
 page.finish();
 
 // Start a new page.
-let mut page = document.start_page_with(PageSettings::new(200.0, 200.0));
+let mut page = document.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
 // Create the triangle.
 let triangle = {
     let mut pb = PathBuilder::new();

--- a/crates/krilla/src/page.rs
+++ b/crates/krilla/src/page.rs
@@ -42,12 +42,19 @@ pub struct PageSettings {
 
 impl PageSettings {
     /// Create new page settings and define the size of the page surface.
-    pub fn new(width: f32, height: f32) -> Self {
+    pub fn new(size: Size) -> Self {
         Self {
-            media_box: Some(Rect::from_xywh(0.0, 0.0, width, height).unwrap()),
-            surface_size: Size::from_wh(width, height).unwrap(),
+            media_box: Some(Rect::from_xywh(0.0, 0.0, size.width(), size.height()).unwrap()),
+            surface_size: size,
             ..Default::default()
         }
+    }
+
+    /// Try to create new page settings with the specified width and height.
+    ///
+    /// Returns `None` if either the width or the height is not > 0.
+    pub fn from_wh(width: f32, height: f32) -> Option<Self> {
+        Some(Self::new(Size::from_wh(width, height)?))
     }
 
     /// Change the media box.


### PR DESCRIPTION
Fix #307 by checking that the page size is at least 3x3 units.

If you think this is too restrictive in regard to PDF 2.0, I can just revert to the initial commit, which only requires non-zero sized pages.

The changes in the readme are a bit noisy (my editor did that automatically), I can undo them if you want.

~~CI failure seems to be unrelated again :)~~