### PR TITLE
Use `IndexMap` to sort fonts by usage order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "image 0.25.2",
  "image-webp",
  "imagesize 0.14.0",
+ "indexmap",
  "once_cell",
  "oxipng",
  "parley",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ hayro-write = "0.3.0"
 image = { version = "0.25.1", default-features = false }
 imagesize = "0.14.0"
 image-webp = "0.2.1"
+indexmap = "2.10.0"
 krilla = { path = "crates/krilla", version = "0.5.0" }
 krilla-svg = { path = "crates/krilla-svg", version = "0.2.0" }
 krilla-macros = { path = "crates/krilla-macros" }

--- a/crates/krilla/Cargo.toml
+++ b/crates/krilla/Cargo.toml
@@ -35,6 +35,7 @@ gif = { workspace = true, optional = true }
 hayro-write = { workspace = true, optional = true }
 image-webp = { workspace = true, optional = true }
 imagesize = { workspace = true, optional = true }
+indexmap = { workspace = true }
 once_cell = { workspace = true }
 pdf-writer = { workspace = true }
 rayon = { workspace = true, optional = true }

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -5,6 +5,7 @@ use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 use std::sync::Arc;
 
+use indexmap::IndexMap;
 use pdf_writer::types::{StructRole, StructRole2};
 use pdf_writer::writers::{OutputIntent, StructTreeRoot};
 use pdf_writer::{Chunk, Finish, Limits, Name, Pdf, Ref, Str, TextStr};
@@ -655,9 +656,7 @@ impl SerializeContext {
 
     fn serialize_fonts(&mut self) -> KrillaResult<()> {
         let fonts = self.global_objects.font_map.take();
-        let mut sorted = fonts.values().collect::<Vec<_>>();
-        sorted.sort_by_key(|e| e.borrow().font().sip_hash());
-        for font_container in sorted {
+        for font_container in fonts.values() {
             let borrowed = font_container.borrow();
 
             if !borrowed.type3_mapper().is_empty() {
@@ -938,7 +937,7 @@ pub(crate) struct GlobalObjects {
     // Needs to be pub(crate) because writing of named destinations happens in `ChunkContainer`.
     pub(crate) named_destinations: MaybeTaken<HashMap<NamedDestination, Ref>>,
     /// A map from fonts to font container.
-    font_map: MaybeTaken<HashMap<Font, Rc<RefCell<FontContainer>>>>,
+    font_map: MaybeTaken<IndexMap<Font, Rc<RefCell<FontContainer>>>>,
     /// All XYZ destinations used in the document. The reason we need to store them
     /// separately is that we can only serialize them in the very end, once all pages
     /// have been written, so that we know the Ref of the page they belong to.

--- a/crates/krilla/src/text/mod.rs
+++ b/crates/krilla/src/text/mod.rs
@@ -137,10 +137,6 @@ impl FontContainer {
             res
         }
     }
-
-    pub(crate) fn font(&self) -> &Font {
-        &self.font
-    }
 }
 
 pub(crate) trait PdfFont {


### PR DESCRIPTION
Use `IndexMap` to sort fonts by usage order. If the order isn't deterministic, the PDF won't be deterministic anyway.
The hashing approach previously used produces different orders on my local machine and a github actions runner.