### PR TITLE
Generate stable hashes between 32- and 64-bit architectures

### DIFF
--- a/crates/krilla/src/chunk_container.rs
+++ b/crates/krilla/src/chunk_container.rs
@@ -8,7 +8,7 @@ use crate::error::KrillaResult;
 use crate::interchange::metadata::Metadata;
 use crate::metadata::PageLayout;
 use crate::serialize::SerializeContext;
-use crate::util::{hash_base64, Deferred};
+use crate::util::{stable_hash_base64, Deferred};
 
 type DChunk = Deferred<Chunk>;
 
@@ -105,13 +105,13 @@ impl ChunkContainer {
             );
         }
 
-        let instance_id = hash_base64(pdf.as_bytes());
+        let instance_id = stable_hash_base64(pdf.as_bytes());
 
         let document_id = if let Some(metadata) = &self.metadata {
             if let Some(document_id) = &metadata.document_id {
-                hash_base64(&(sc.serialize_settings().pdf_version().as_str(), document_id))
+                stable_hash_base64(&(sc.serialize_settings().pdf_version().as_str(), document_id))
             } else if metadata.title.is_some() && metadata.authors.is_some() {
-                hash_base64(&(
+                stable_hash_base64(&(
                     sc.serialize_settings().pdf_version().as_str(),
                     &metadata.title,
                     &metadata.authors,

--- a/crates/krilla/src/text/cid.rs
+++ b/crates/krilla/src/text/cid.rs
@@ -22,7 +22,7 @@ use crate::surface::Location;
 use crate::text::outline::OutlineBuilder;
 use crate::text::Font;
 use crate::text::GlyphId;
-use crate::util::{hash128, SliceExt};
+use crate::util::{stable_hash128, SliceExt};
 
 const SUBSET_TAG_LEN: usize = 6;
 pub(crate) const IDENTITY_H: &str = "Identity-H";
@@ -405,7 +405,7 @@ impl CIDFont {
 /// Create a tag for a font subset.
 pub(crate) fn subset_tag<T: Hash>(data: &T) -> String {
     const BASE: u128 = 26;
-    let mut hash = hash128(data);
+    let mut hash = stable_hash128(data);
     let mut letter = [b'A'; SUBSET_TAG_LEN];
     for l in letter.iter_mut() {
         *l = b'A' + (hash % BASE) as u8;


### PR DESCRIPTION
This is only done for hashes that end up in documents, such as the `instance_id` and font `subset_tag`s.