### PR TITLE
Use fixed size integer for page label offset

### DIFF
--- a/crates/krilla-tests/src/page.rs
+++ b/crates/krilla-tests/src/page.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroUsize;
+use std::num::NonZeroU32;
 
 use krilla::geom::Rect;
 use krilla::page::{NumberingStyle, PageLabel, PageSettings};
@@ -35,7 +35,7 @@ fn page_label(d: &mut Document) {
         .with_page_label(PageLabel::new(
             Some(NumberingStyle::LowerRoman),
             None,
-            NonZeroUsize::new(2),
+            NonZeroU32::new(2),
         ));
 
     d.start_page_with(settings);

--- a/crates/krilla/src/page.rs
+++ b/crates/krilla/src/page.rs
@@ -1,7 +1,7 @@
 //! Working with pages of a PDF document.
 
 use std::cell::OnceCell;
-use std::num::NonZeroUsize;
+use std::num::NonZeroU32;
 use std::ops::DerefMut;
 
 use pdf_writer::types::TabOrder;
@@ -468,7 +468,7 @@ pub struct PageLabel {
     /// The prefix of the page label.
     pub(crate) prefix: Option<String>,
     /// The numeric value of the page label.
-    pub(crate) offset: Option<NonZeroUsize>,
+    pub(crate) offset: Option<NonZeroU32>,
 }
 
 impl PageLabel {
@@ -476,7 +476,7 @@ impl PageLabel {
     pub fn new(
         style: Option<NumberingStyle>,
         prefix: Option<String>,
-        offset: Option<NonZeroUsize>,
+        offset: Option<NonZeroU32>,
     ) -> Self {
         Self {
             style,


### PR DESCRIPTION
Since the page label offset can be user specified data, I think it's a good idea to always represent it the same way.
In the typst test suite I discovered [an issue](https://github.com/typst/typst/actions/runs/19760154557/job/56619953511#step:7:238) where on 32-bit architectures the offset couldn't be stored in an `usize` and so the `offset` field would be `None`. This lead to only one deduplicated page label on 32-bit and tree separate labels on 64-bit. Since all numbers have to be converted to an `i32` for `pdf-writer` in the end anyway, a `NonZeroU32` should be enough. 