### PR TITLE
Fix crash for 0-byte embedded PDF file

### DIFF
--- a/crates/krilla-tests/src/embed.rs
+++ b/crates/krilla-tests/src/embed.rs
@@ -67,6 +67,19 @@ fn file_4() -> EmbeddedFile {
     }
 }
 
+pub(crate) fn empty_file() -> EmbeddedFile {
+    EmbeddedFile {
+        path: "empty_file".to_string(),
+        mime_type: Some(MimeType::new("text/plain").unwrap()),
+        description: Some("A zero-byte file.".to_string()),
+        association_kind: AssociationKind::Supplement,
+        data: vec![].into(),
+        modification_date: Some(DateTime::new(2001)),
+        compress: None,
+        location: None,
+    }
+}
+
 #[snapshot(document)]
 fn embedded_file(d: &mut Document) {
     let file = file_1();
@@ -106,6 +119,12 @@ fn embedded_file_multiple(d: &mut Document) {
     d.embed_file(f1);
     d.embed_file(f2);
     d.embed_file(f3);
+}
+
+#[snapshot(document)]
+fn embedded_zero_byte_file(d: &mut Document) {
+    let file = empty_file();
+    d.embed_file(file);
 }
 
 pub(crate) fn embedded_file_impl(d: &mut Document) {

--- a/crates/krilla/src/stream.rs
+++ b/crates/krilla/src/stream.rs
@@ -237,7 +237,9 @@ impl<'a> FilterStreamBuilder<'a> {
         let filter_stream = Self::new_from_binary_data(content);
 
         const MAX_COMPRESSED_SIZE: usize = 75;
-        if 100 * filter_stream.content.len() / content.len() > MAX_COMPRESSED_SIZE {
+        if content.is_empty()
+            || 100 * filter_stream.content.len() / content.len() > MAX_COMPRESSED_SIZE
+        {
             return Self::empty(content);
         }
 

--- a/refs/snapshots/embedded_zero_byte_file.txt
+++ b/refs/snapshots/embedded_zero_byte_file.txt
@@ -1,0 +1,90 @@
+%PDF-1.7
+%AAAA
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [2 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+  >>
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 3 0 R
+>>
+endobj
+
+3 0 obj
+<<
+  /Length 0
+>>
+stream
+
+endstream
+endobj
+
+4 0 obj
+<<
+  /Length 0
+  /Type /EmbeddedFile
+  /Subtype /text#2Fplain
+  /Params <<
+    /Size 0
+    /ModDate (D:20010101000000Z)
+  >>
+>>
+stream
+
+endstream
+endobj
+
+5 0 obj
+<<
+  /Type /Filespec
+  /F (empty_file)
+  /UF (empty_file)
+  /EF <<
+    /F 4 0 R
+    /UF 4 0 R
+  >>
+  /Desc (A zero-byte file.)
+>>
+endobj
+
+6 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Names <<
+    /EmbeddedFiles <<
+      /Names [(empty_file) 5 0 R]
+    >>
+  >>
+>>
+endobj
+
+xref
+0 7
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000239 00000 n
+0000000291 00000 n
+0000000453 00000 n
+0000000599 00000 n
+trailer
+<<
+  /Size 7
+  /Root 6 0 R
+  /ID [(QtaJE+9l0C4qjS4YgdnwzQ==) (QtaJE+9l0C4qjS4YgdnwzQ==)]
+>>
+startxref
+733
+%%EOF


### PR DESCRIPTION
Fixes https://github.com/typst/typst/issues/7518 by adding the missing edge case check.

I added a test for this.

By the way,

https://github.com/LaurenzV/krilla/blob/f2a370f2f56d2ba3ccef549eba5d2327242a40fd/crates/krilla-tests/src/embed.rs?plain=1#L15

is not a standard Media Type. A standard one is [`text/plain`](https://www.iana.org/assignments/media-types/text/plain).