### PR TITLE
Allow specifying open/closed state on `OutlineNode`

### DIFF
--- a/crates/krilla-tests/src/outline.rs
+++ b/crates/krilla-tests/src/outline.rs
@@ -42,6 +42,92 @@ fn outline_simple(d: &mut Document) {
     d.set_outline(outline);
 }
 #[snapshot(document)]
+fn outline_open_state(d: &mut Document) {
+    let fills = [red_fill(1.0), green_fill(1.0), blue_fill(1.0)];
+    for (index, fill) in fills.into_iter().enumerate() {
+        let factor = index as f32 * 50.0;
+        let path = rect_to_path(factor, factor, 100.0 + factor, 100.0 + factor);
+        let mut page = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
+        let mut surface = page.surface();
+        surface.set_fill(Some(fill));
+        surface.draw_path(&path);
+        surface.finish();
+        page.finish();
+    }
+    let mut outline = Outline::new();
+
+    let mut child1 = OutlineNode::new(
+        "Heading 1".to_string(),
+        XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
+    );
+    child1.set_open(true);
+    child1.push_child(OutlineNode::new(
+        "Heading 1.1".to_string(),
+        XyzDestination::new(1, Point::from_xy(50.0, 50.0)),
+    ));
+
+    let child2 = OutlineNode::new(
+        "Heading 2".to_string(),
+        XyzDestination::new(2, Point::from_xy(100.0, 100.0)),
+    );
+
+    outline.push_child(child1);
+    outline.push_child(child2);
+
+    d.set_outline(outline);
+}
+
+#[snapshot(document)]
+fn outline_mixed_state(d: &mut Document) {
+    let fills = [red_fill(1.0), green_fill(1.0), blue_fill(1.0)];
+    for (index, fill) in fills.into_iter().enumerate() {
+        let factor = index as f32 * 50.0;
+        let path = rect_to_path(factor, factor, 100.0 + factor, 100.0 + factor);
+        let mut page = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
+        let mut surface = page.surface();
+        surface.set_fill(Some(fill));
+        surface.draw_path(&path);
+        surface.finish();
+        page.finish();
+    }
+    let mut outline = Outline::new();
+
+    // Open parent containing an open child, so the root /Outlines must count
+    // grand-children as visible too.
+    let mut child1 = OutlineNode::new_with_state(
+        "Heading 1".to_string(),
+        XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
+        true,
+    );
+    let mut nested = OutlineNode::new_with_state(
+        "Heading 1.1".to_string(),
+        XyzDestination::new(1, Point::from_xy(50.0, 50.0)),
+        true,
+    );
+    nested.push_child(OutlineNode::new(
+        "Heading 1.1.1".to_string(),
+        XyzDestination::new(1, Point::from_xy(60.0, 60.0)),
+    ));
+    child1.push_child(nested);
+
+    // Closed parent; its child should contribute to the magnitude but not be
+    // visible from the root's perspective.
+    let mut child2 = OutlineNode::new(
+        "Heading 2".to_string(),
+        XyzDestination::new(2, Point::from_xy(100.0, 100.0)),
+    );
+    child2.push_child(OutlineNode::new(
+        "Heading 2.1".to_string(),
+        XyzDestination::new(2, Point::from_xy(120.0, 120.0)),
+    ));
+
+    outline.push_child(child1);
+    outline.push_child(child2);
+
+    d.set_outline(outline);
+}
+
+#[snapshot(document)]
 fn outline_with_empty_title(d: &mut Document) {
     let mut outline = Outline::new();
 

--- a/crates/krilla-tests/src/outline.rs
+++ b/crates/krilla-tests/src/outline.rs
@@ -59,8 +59,8 @@ fn outline_open_state(d: &mut Document) {
     let mut child1 = OutlineNode::new(
         "Heading 1".to_string(),
         XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
-    );
-    child1.set_open(true);
+    )
+    .with_open(true);
     child1.push_child(OutlineNode::new(
         "Heading 1.1".to_string(),
         XyzDestination::new(1, Point::from_xy(50.0, 50.0)),

--- a/crates/krilla-tests/src/outline.rs
+++ b/crates/krilla-tests/src/outline.rs
@@ -43,17 +43,10 @@ fn outline_simple(d: &mut Document) {
 }
 #[snapshot(document)]
 fn outline_open_state(d: &mut Document) {
-    let fills = [red_fill(1.0), green_fill(1.0), blue_fill(1.0)];
-    for (index, fill) in fills.into_iter().enumerate() {
-        let factor = index as f32 * 50.0;
-        let path = rect_to_path(factor, factor, 100.0 + factor, 100.0 + factor);
-        let mut page = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
-        let mut surface = page.surface();
-        surface.set_fill(Some(fill));
-        surface.draw_path(&path);
-        surface.finish();
-        page.finish();
+    for _ in 0..3 {
+        let _ = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     }
+
     let mut outline = Outline::new();
 
     let mut child1 = OutlineNode::new(
@@ -79,21 +72,12 @@ fn outline_open_state(d: &mut Document) {
 
 #[snapshot(document)]
 fn outline_mixed_state(d: &mut Document) {
-    let fills = [red_fill(1.0), green_fill(1.0), blue_fill(1.0)];
-    for (index, fill) in fills.into_iter().enumerate() {
-        let factor = index as f32 * 50.0;
-        let path = rect_to_path(factor, factor, 100.0 + factor, 100.0 + factor);
-        let mut page = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
-        let mut surface = page.surface();
-        surface.set_fill(Some(fill));
-        surface.draw_path(&path);
-        surface.finish();
-        page.finish();
+    for _ in 0..3 {
+        let _ = d.start_page_with(PageSettings::from_wh(200.0, 200.0).unwrap());
     }
+
     let mut outline = Outline::new();
 
-    // Open parent containing an open child, so the root /Outlines must count
-    // grand-children as visible too.
     let mut child1 = OutlineNode::new(
         "Heading 1".to_string(),
         XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
@@ -110,8 +94,6 @@ fn outline_mixed_state(d: &mut Document) {
     ));
     child1.push_child(nested);
 
-    // Closed parent; its child should contribute to the magnitude but not be
-    // visible from the root's perspective.
     let mut child2 = OutlineNode::new(
         "Heading 2".to_string(),
         XyzDestination::new(2, Point::from_xy(100.0, 100.0)),

--- a/crates/krilla-tests/src/outline.rs
+++ b/crates/krilla-tests/src/outline.rs
@@ -94,16 +94,16 @@ fn outline_mixed_state(d: &mut Document) {
 
     // Open parent containing an open child, so the root /Outlines must count
     // grand-children as visible too.
-    let mut child1 = OutlineNode::new_with_state(
+    let mut child1 = OutlineNode::new(
         "Heading 1".to_string(),
         XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
-        true,
-    );
-    let mut nested = OutlineNode::new_with_state(
+    )
+    .with_open(true);
+    let mut nested = OutlineNode::new(
         "Heading 1.1".to_string(),
         XyzDestination::new(1, Point::from_xy(50.0, 50.0)),
-        true,
-    );
+    )
+    .with_open(true);
     nested.push_child(OutlineNode::new(
         "Heading 1.1.1".to_string(),
         XyzDestination::new(1, Point::from_xy(60.0, 60.0)),

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -141,7 +141,7 @@ impl OutlineNode {
     /// `text` is the string that should be displayed in the outline tree, and
     /// `destination` is the destination that should be jumped to when clicking on
     /// the outline entry. The node is created in the *closed* state; use
-    /// [`OutlineNode::new_with_state`] or [`OutlineNode::set_open`] to change this.
+    /// [`OutlineNode::with_open`] or [`OutlineNode::set_open`] to change this.
     pub fn new(text: String, destination: XyzDestination) -> Self {
         Self {
             children: vec![],
@@ -151,26 +151,19 @@ impl OutlineNode {
         }
     }
 
-    /// Create a new outline node, explicitly specifying the initial open state.
+    /// Set whether this node is initially open (children shown expanded).
     ///
     /// If `open` is `true`, the node's children will be shown expanded when the
     /// document is opened in a PDF viewer; if `false`, the children will be
     /// collapsed. Leaf nodes (nodes without children) are unaffected by this flag.
-    pub fn new_with_state(text: String, destination: XyzDestination, open: bool) -> Self {
-        Self {
-            children: vec![],
-            text,
-            destination,
-            open,
-        }
+    pub fn with_open(mut self, open: bool) -> Self {
+        self.open = open;
+        self
     }
 
     /// Set whether this node is initially open (children shown expanded).
-    ///
-    /// Returns `&mut Self` to allow chaining with other builder-style calls.
-    pub fn set_open(&mut self, open: bool) -> &mut Self {
+    pub fn set_open(&mut self, open: bool) {
         self.open = open;
-        self
     }
 
     /// Add a new child to the outline node.

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -140,8 +140,7 @@ impl OutlineNode {
     ///
     /// `text` is the string that should be displayed in the outline tree, and
     /// `destination` is the destination that should be jumped to when clicking on
-    /// the outline entry. The node is created in the *closed* state; use
-    /// [`OutlineNode::with_open`] to change this.
+    /// the outline entry.
     pub fn new(text: String, destination: XyzDestination) -> Self {
         Self {
             children: vec![],

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -150,7 +150,7 @@ impl OutlineNode {
     /// If `open` is `true`, the node's children will be shown expanded when the
     /// document is opened in a PDF viewer; if `false`, the children will be
     /// collapsed. Leaf nodes (nodes without children) are unaffected by this flag.
-    /// 
+    ///
     /// By default, this flag is set to `false`.
     pub fn with_open(mut self, open: bool) -> Self {
         self.open = open;
@@ -169,7 +169,7 @@ impl OutlineNode {
         root: Ref,
         next: Option<Ref>,
         prev: Option<Ref>,
-    ) -> KrillaResult<Chunk> {
+    ) -> KrillaResult<(Chunk, usize)> {
         let mut chunk = Chunk::new();
 
         let mut sub_chunks = vec![];
@@ -185,7 +185,7 @@ impl OutlineNode {
             outline_entry.prev(prev);
         }
 
-        serialize_children(
+        let visible_child_count = serialize_children(
             &self.children,
             root,
             &mut sub_chunks,
@@ -205,7 +205,17 @@ impl OutlineNode {
             chunk.extend(&sub_chunk);
         }
 
-        Ok(chunk)
+        // See the algorithm described in the PDF spec. When recursing down, we
+        // do not go into nodes that whose count is negative (i.e. nodes that are
+        // closed). Therefore, in case the node is closed, the visible count is
+        // just the node itself, so 1.
+        let visible_count = if self.open {
+            1 + visible_child_count
+        } else {
+            1
+        };
+
+        Ok((chunk, visible_count))
     }
 }
 
@@ -216,7 +226,9 @@ fn serialize_children(
     sc: &mut SerializeContext,
     outlineable: &mut impl Outlineable,
     negate_count: bool,
-) -> KrillaResult<()> {
+) -> KrillaResult<usize> {
+    let mut visible_count = 0;
+
     if !children.is_empty() {
         let first = sc.new_ref();
         let mut last = first;
@@ -233,7 +245,9 @@ fn serialize_children(
 
             last = cur.unwrap();
 
-            sub_chunks.push(children[i].serialize(sc, root, last, next, prev)?);
+            let (chunk, child_visible_count) = children[i].serialize(sc, root, last, next, prev)?;
+            visible_count += child_visible_count;
+            sub_chunks.push(chunk);
 
             prev = cur;
             cur = next;
@@ -242,26 +256,12 @@ fn serialize_children(
         outlineable.first(first);
         outlineable.last(last);
 
-        let mut count = i32::try_from(visible_descendant_count(children)).unwrap();
+        let mut count = i32::try_from(visible_count).unwrap();
         if negate_count {
             count = -count;
         }
         outlineable.count(count);
     }
 
-    Ok(())
-}
-
-/// Recursively count outline items visible below a given set of siblings,
-/// descending into a node only when that node itself is open. This matches the
-/// semantics of the `/Count` entry described in PDF 1.7 §12.3.3.
-fn visible_descendant_count(children: &[OutlineNode]) -> usize {
-    let mut total = 0;
-    for child in children {
-        total += 1;
-        if child.open {
-            total += visible_descendant_count(&child.children);
-        }
-    }
-    total
+    Ok(visible_count)
 }

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -141,7 +141,7 @@ impl OutlineNode {
     /// `text` is the string that should be displayed in the outline tree, and
     /// `destination` is the destination that should be jumped to when clicking on
     /// the outline entry. The node is created in the *closed* state; use
-    /// [`OutlineNode::with_open`] or [`OutlineNode::set_open`] to change this.
+    /// [`OutlineNode::with_open`] to change this.
     pub fn new(text: String, destination: XyzDestination) -> Self {
         Self {
             children: vec![],
@@ -159,11 +159,6 @@ impl OutlineNode {
     pub fn with_open(mut self, open: bool) -> Self {
         self.open = open;
         self
-    }
-
-    /// Set whether this node is initially open (children shown expanded).
-    pub fn set_open(&mut self, open: bool) {
-        self.open = open;
     }
 
     /// Add a new child to the outline node.

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -155,6 +155,8 @@ impl OutlineNode {
     /// If `open` is `true`, the node's children will be shown expanded when the
     /// document is opened in a PDF viewer; if `false`, the children will be
     /// collapsed. Leaf nodes (nodes without children) are unaffected by this flag.
+    /// 
+    /// By default, this flag is set to `false`.
     pub fn with_open(mut self, open: bool) -> Self {
         self.open = open;
         self

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -118,6 +118,11 @@ impl Outline {
 ///
 /// This represents either an intermediate node in the outline tree, or a leaf node
 /// if it does not contain any further children itself.
+///
+/// An outline node can be either *open* or *closed*, which controls whether its
+/// children are initially shown expanded or collapsed when the document is opened
+/// in a PDF viewer. The sign of the `/Count` entry emitted in the PDF (see PDF 1.7
+/// §12.3.3) reflects this state. By default, a node is *closed*.
 #[derive(Debug, Clone)]
 pub struct OutlineNode {
     /// The children of the outline node.
@@ -126,6 +131,8 @@ pub struct OutlineNode {
     text: String,
     /// The destination of the outline entry.
     destination: XyzDestination,
+    /// Whether this node is initially open (children shown expanded).
+    open: bool,
 }
 
 impl OutlineNode {
@@ -133,13 +140,37 @@ impl OutlineNode {
     ///
     /// `text` is the string that should be displayed in the outline tree, and
     /// `destination` is the destination that should be jumped to when clicking on
-    /// the outline entry.
+    /// the outline entry. The node is created in the *closed* state; use
+    /// [`OutlineNode::new_with_state`] or [`OutlineNode::set_open`] to change this.
     pub fn new(text: String, destination: XyzDestination) -> Self {
         Self {
             children: vec![],
             text,
             destination,
+            open: false,
         }
+    }
+
+    /// Create a new outline node, explicitly specifying the initial open state.
+    ///
+    /// If `open` is `true`, the node's children will be shown expanded when the
+    /// document is opened in a PDF viewer; if `false`, the children will be
+    /// collapsed. Leaf nodes (nodes without children) are unaffected by this flag.
+    pub fn new_with_state(text: String, destination: XyzDestination, open: bool) -> Self {
+        Self {
+            children: vec![],
+            text,
+            destination,
+            open,
+        }
+    }
+
+    /// Set whether this node is initially open (children shown expanded).
+    ///
+    /// Returns `&mut Self` to allow chaining with other builder-style calls.
+    pub fn set_open(&mut self, open: bool) -> &mut Self {
+        self.open = open;
+        self
     }
 
     /// Add a new child to the outline node.
@@ -176,7 +207,7 @@ impl OutlineNode {
             &mut sub_chunks,
             sc,
             &mut outline_entry,
-            true,
+            !self.open,
         )?;
 
         outline_entry.title(TextStr(&self.text));
@@ -227,7 +258,7 @@ fn serialize_children(
         outlineable.first(first);
         outlineable.last(last);
 
-        let mut count = i32::try_from(children.len()).unwrap();
+        let mut count = i32::try_from(visible_descendant_count(children)).unwrap();
         if negate_count {
             count = -count;
         }
@@ -235,4 +266,18 @@ fn serialize_children(
     }
 
     Ok(())
+}
+
+/// Recursively count outline items visible below a given set of siblings,
+/// descending into a node only when that node itself is open. This matches the
+/// semantics of the `/Count` entry described in PDF 1.7 §12.3.3.
+fn visible_descendant_count(children: &[OutlineNode]) -> usize {
+    let mut total = 0;
+    for child in children {
+        total += 1;
+        if child.open {
+            total += visible_descendant_count(&child.children);
+        }
+    }
+    total
 }

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -118,11 +118,6 @@ impl Outline {
 ///
 /// This represents either an intermediate node in the outline tree, or a leaf node
 /// if it does not contain any further children itself.
-///
-/// An outline node can be either *open* or *closed*, which controls whether its
-/// children are initially shown expanded or collapsed when the document is opened
-/// in a PDF viewer. The sign of the `/Count` entry emitted in the PDF (see PDF 1.7
-/// §12.3.3) reflects this state. By default, a node is *closed*.
 #[derive(Debug, Clone)]
 pub struct OutlineNode {
     /// The children of the outline node.

--- a/refs/snapshots/outline_mixed_state.txt
+++ b/refs/snapshots/outline_mixed_state.txt
@@ -103,19 +103,10 @@ endobj
 
 14 0 obj
 <<
-  /Length 66
+  /Length 0
 >>
 stream
-q
-1 0 0 -1 0 200 cm
-1 0 0 rg
-0 0 m
-100 0 l
-100 100 l
-0 100 l
-h
-f
-Q
+
 endstream
 endobj
 
@@ -133,19 +124,10 @@ endobj
 
 16 0 obj
 <<
-  /Length 70
+  /Length 0
 >>
 stream
-q
-1 0 0 -1 0 200 cm
-0 1 0 rg
-50 50 m
-150 50 l
-150 150 l
-50 150 l
-h
-f
-Q
+
 endstream
 endobj
 
@@ -163,19 +145,10 @@ endobj
 
 18 0 obj
 <<
-  /Length 74
+  /Length 0
 >>
 stream
-q
-1 0 0 -1 0 200 cm
-0 0 1 rg
-100 100 m
-200 100 l
-200 200 l
-100 200 l
-h
-f
-Q
+
 endstream
 endobj
 
@@ -204,17 +177,17 @@ xref
 0000000857 00000 n
 0000000898 00000 n
 0000001059 00000 n
-0000001179 00000 n
-0000001340 00000 n
-0000001464 00000 n
-0000001625 00000 n
-0000001753 00000 n
+0000001112 00000 n
+0000001273 00000 n
+0000001326 00000 n
+0000001487 00000 n
+0000001540 00000 n
 trailer
 <<
   /Size 20
   /Root 19 0 R
-  /ID [(70Ks5Y1BvjxYoJSfJnx+Ig==) (70Ks5Y1BvjxYoJSfJnx+Ig==)]
+  /ID [(13Lex+8O1cIBK5pelR2r1Q==) (13Lex+8O1cIBK5pelR2r1Q==)]
 >>
 startxref
-1826
+1613
 %%EOF

--- a/refs/snapshots/outline_mixed_state.txt
+++ b/refs/snapshots/outline_mixed_state.txt
@@ -1,0 +1,220 @@
+%PDF-1.7
+%AAAA
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 3
+  /Kids [13 0 R 15 0 R 17 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Outlines
+  /First 3 0 R
+  /Last 6 0 R
+  /Count 4
+>>
+endobj
+
+3 0 obj
+<<
+  /Parent 2 0 R
+  /Next 6 0 R
+  /First 4 0 R
+  /Last 4 0 R
+  /Count 2
+  /Title (Heading 1)
+  /Dest 10 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Parent 3 0 R
+  /First 5 0 R
+  /Last 5 0 R
+  /Count 1
+  /Title (Heading 1.1)
+  /Dest 9 0 R
+>>
+endobj
+
+5 0 obj
+<<
+  /Parent 4 0 R
+  /Title (Heading 1.1.1)
+  /Dest 8 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Parent 2 0 R
+  /Prev 3 0 R
+  /First 7 0 R
+  /Last 7 0 R
+  /Count -1
+  /Title (Heading 2)
+  /Dest 12 0 R
+>>
+endobj
+
+7 0 obj
+<<
+  /Parent 6 0 R
+  /Title (Heading 2.1)
+  /Dest 11 0 R
+>>
+endobj
+
+8 0 obj
+[15 0 R /XYZ 60 140 0]
+endobj
+
+9 0 obj
+[15 0 R /XYZ 50 150 0]
+endobj
+
+10 0 obj
+[13 0 R /XYZ 0 200 0]
+endobj
+
+11 0 obj
+[17 0 R /XYZ 120 80 0]
+endobj
+
+12 0 obj
+[17 0 R /XYZ 100 100 0]
+endobj
+
+13 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+  >>
+  /MediaBox [0 0 200 200]
+  /Parent 1 0 R
+  /Contents 14 0 R
+>>
+endobj
+
+14 0 obj
+<<
+  /Length 66
+>>
+stream
+q
+1 0 0 -1 0 200 cm
+1 0 0 rg
+0 0 m
+100 0 l
+100 100 l
+0 100 l
+h
+f
+Q
+endstream
+endobj
+
+15 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+  >>
+  /MediaBox [0 0 200 200]
+  /Parent 1 0 R
+  /Contents 16 0 R
+>>
+endobj
+
+16 0 obj
+<<
+  /Length 70
+>>
+stream
+q
+1 0 0 -1 0 200 cm
+0 1 0 rg
+50 50 m
+150 50 l
+150 150 l
+50 150 l
+h
+f
+Q
+endstream
+endobj
+
+17 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+  >>
+  /MediaBox [0 0 200 200]
+  /Parent 1 0 R
+  /Contents 18 0 R
+>>
+endobj
+
+18 0 obj
+<<
+  /Length 74
+>>
+stream
+q
+1 0 0 -1 0 200 cm
+0 0 1 rg
+100 100 m
+200 100 l
+200 200 l
+100 200 l
+h
+f
+Q
+endstream
+endobj
+
+19 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Outlines 2 0 R
+>>
+endobj
+
+xref
+0 20
+0000000000 65535 f
+0000000016 00000 n
+0000000095 00000 n
+0000000175 00000 n
+0000000303 00000 n
+0000000418 00000 n
+0000000495 00000 n
+0000000624 00000 n
+0000000700 00000 n
+0000000739 00000 n
+0000000778 00000 n
+0000000817 00000 n
+0000000857 00000 n
+0000000898 00000 n
+0000001059 00000 n
+0000001179 00000 n
+0000001340 00000 n
+0000001464 00000 n
+0000001625 00000 n
+0000001753 00000 n
+trailer
+<<
+  /Size 20
+  /Root 19 0 R
+  /ID [(70Ks5Y1BvjxYoJSfJnx+Ig==) (70Ks5Y1BvjxYoJSfJnx+Ig==)]
+>>
+startxref
+1826
+%%EOF

--- a/refs/snapshots/outline_open_state.txt
+++ b/refs/snapshots/outline_open_state.txt
@@ -1,0 +1,186 @@
+%PDF-1.7
+%AAAA
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 3
+  /Kids [9 0 R 11 0 R 13 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Outlines
+  /First 3 0 R
+  /Last 5 0 R
+  /Count 3
+>>
+endobj
+
+3 0 obj
+<<
+  /Parent 2 0 R
+  /Next 5 0 R
+  /First 4 0 R
+  /Last 4 0 R
+  /Count 1
+  /Title (Heading 1)
+  /Dest 7 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Parent 3 0 R
+  /Title (Heading 1.1)
+  /Dest 6 0 R
+>>
+endobj
+
+5 0 obj
+<<
+  /Parent 2 0 R
+  /Prev 3 0 R
+  /Title (Heading 2)
+  /Dest 8 0 R
+>>
+endobj
+
+6 0 obj
+[11 0 R /XYZ 50 150 0]
+endobj
+
+7 0 obj
+[9 0 R /XYZ 0 200 0]
+endobj
+
+8 0 obj
+[13 0 R /XYZ 100 100 0]
+endobj
+
+9 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+  >>
+  /MediaBox [0 0 200 200]
+  /Parent 1 0 R
+  /Contents 10 0 R
+>>
+endobj
+
+10 0 obj
+<<
+  /Length 66
+>>
+stream
+q
+1 0 0 -1 0 200 cm
+1 0 0 rg
+0 0 m
+100 0 l
+100 100 l
+0 100 l
+h
+f
+Q
+endstream
+endobj
+
+11 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+  >>
+  /MediaBox [0 0 200 200]
+  /Parent 1 0 R
+  /Contents 12 0 R
+>>
+endobj
+
+12 0 obj
+<<
+  /Length 70
+>>
+stream
+q
+1 0 0 -1 0 200 cm
+0 1 0 rg
+50 50 m
+150 50 l
+150 150 l
+50 150 l
+h
+f
+Q
+endstream
+endobj
+
+13 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+  >>
+  /MediaBox [0 0 200 200]
+  /Parent 1 0 R
+  /Contents 14 0 R
+>>
+endobj
+
+14 0 obj
+<<
+  /Length 74
+>>
+stream
+q
+1 0 0 -1 0 200 cm
+0 0 1 rg
+100 100 m
+200 100 l
+200 200 l
+100 200 l
+h
+f
+Q
+endstream
+endobj
+
+15 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Outlines 2 0 R
+>>
+endobj
+
+xref
+0 16
+0000000000 65535 f
+0000000016 00000 n
+0000000094 00000 n
+0000000174 00000 n
+0000000301 00000 n
+0000000376 00000 n
+0000000463 00000 n
+0000000502 00000 n
+0000000539 00000 n
+0000000579 00000 n
+0000000739 00000 n
+0000000859 00000 n
+0000001020 00000 n
+0000001144 00000 n
+0000001305 00000 n
+0000001433 00000 n
+trailer
+<<
+  /Size 16
+  /Root 15 0 R
+  /ID [(7gnq6jT5vfRVVpmRhy8mqw==) (7gnq6jT5vfRVVpmRhy8mqw==)]
+>>
+startxref
+1506
+%%EOF

--- a/refs/snapshots/outline_open_state.txt
+++ b/refs/snapshots/outline_open_state.txt
@@ -73,19 +73,10 @@ endobj
 
 10 0 obj
 <<
-  /Length 66
+  /Length 0
 >>
 stream
-q
-1 0 0 -1 0 200 cm
-1 0 0 rg
-0 0 m
-100 0 l
-100 100 l
-0 100 l
-h
-f
-Q
+
 endstream
 endobj
 
@@ -103,19 +94,10 @@ endobj
 
 12 0 obj
 <<
-  /Length 70
+  /Length 0
 >>
 stream
-q
-1 0 0 -1 0 200 cm
-0 1 0 rg
-50 50 m
-150 50 l
-150 150 l
-50 150 l
-h
-f
-Q
+
 endstream
 endobj
 
@@ -133,19 +115,10 @@ endobj
 
 14 0 obj
 <<
-  /Length 74
+  /Length 0
 >>
 stream
-q
-1 0 0 -1 0 200 cm
-0 0 1 rg
-100 100 m
-200 100 l
-200 200 l
-100 200 l
-h
-f
-Q
+
 endstream
 endobj
 
@@ -170,17 +143,17 @@ xref
 0000000539 00000 n
 0000000579 00000 n
 0000000739 00000 n
-0000000859 00000 n
-0000001020 00000 n
-0000001144 00000 n
-0000001305 00000 n
-0000001433 00000 n
+0000000792 00000 n
+0000000953 00000 n
+0000001006 00000 n
+0000001167 00000 n
+0000001220 00000 n
 trailer
 <<
   /Size 16
   /Root 15 0 R
-  /ID [(7gnq6jT5vfRVVpmRhy8mqw==) (7gnq6jT5vfRVVpmRhy8mqw==)]
+  /ID [(7nNb0MBCRVqNI7RGxH/VFQ==) (7nNb0MBCRVqNI7RGxH/VFQ==)]
 >>
 startxref
-1506
+1293
 %%EOF


### PR DESCRIPTION
## Summary

Add `OutlineNode::new_with_state` and `OutlineNode::set_open` so callers can control whether a node's children appear expanded when the PDF is first opened. The existing `new` constructor keeps producing a *closed* node, so existing users see byte-identical output (the `outline_simple` snapshot is unchanged).

Internally, the `/Count` value is now computed by walking the subtree and summing only the items visible under each node's current open/closed state, as required by PDF 1.7 §12.3.3. For all-closed trees this matches the previous `children.len()`-based count, so existing behavior is preserved; for trees with mixed or open items it produces the correct visible-descendant count.

## Motivation

Downstream consumers that implement the CSS GCPM `bookmark-state: open | closed` property (e.g. Prince, WeasyPrint, and the HTML→PDF engine I'm working on) need a way to mark individual outline entries as initially expanded. Today krilla always emits a negative `/Count` for items with children, so every PDF viewer displays the outline fully collapsed.

## API

```rust
// unchanged — still produces a closed node (default)
OutlineNode::new(text, destination);

// new — explicitly specify the initial state
OutlineNode::new_with_state(text, destination, /* open = */ true);

// new — builder-style mutator
node.set_open(true);
```

No changes to `Outline` (root) — the PDF spec requires the `/Outlines` dictionary's `/Count` to be positive, and that is already the case.

## Test plan

- `cargo test -p krilla` — passes
- `cargo test -p krilla-tests outline` — existing `outline_simple` and `outline_with_empty_title` snapshots unchanged
- New snapshots:
  - `outline_open_state` — a top-level `Heading 1` with `set_open(true)` emits `/Count +1` (positive), and the root `/Outlines` `/Count` grows from 2 to 3 since the open grand-child is now visible
  - `outline_mixed_state` — a three-level tree with mixed open/closed parents; verifies that recursive visibility is counted correctly (open parent: `/Count +2`, closed parent: `/Count -1`, root: `/Count 4`)
- Manually verified the emitted PDFs in a PDF viewer: `outline_open_state.pdf` shows `Heading 1` initially expanded, `outline_mixed_state.pdf` shows the open/closed mix as expected
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -p krilla -p krilla-tests` — no new warnings