### PR TITLE
Add `Document::finish_to_writer` for streaming PDF output

### DIFF
--- a/crates/krilla/src/configure/version.rs
+++ b/crates/krilla/src/configure/version.rs
@@ -82,13 +82,21 @@ impl PdfVersion {
     }
 
     pub(crate) fn set_version(&self, pdf: &mut Pdf) {
+        let (major, minor) = self.version_tuple();
+        pdf.set_version(major, minor);
+    }
+
+    /// The `(major, minor)` numbers for this PDF version. Split out so it
+    /// can be used by streaming-serialize paths that don't have a `Pdf`
+    /// instance handy.
+    pub(crate) fn version_tuple(&self) -> (u8, u8) {
         match self {
-            PdfVersion::Pdf14 => pdf.set_version(1, 4),
-            PdfVersion::Pdf15 => pdf.set_version(1, 5),
-            PdfVersion::Pdf16 => pdf.set_version(1, 6),
-            PdfVersion::Pdf17 => pdf.set_version(1, 7),
-            PdfVersion::Pdf20 => pdf.set_version(2, 0),
-        };
+            PdfVersion::Pdf14 => (1, 4),
+            PdfVersion::Pdf15 => (1, 5),
+            PdfVersion::Pdf16 => (1, 6),
+            PdfVersion::Pdf17 => (1, 7),
+            PdfVersion::Pdf20 => (2, 0),
+        }
     }
 
     pub(crate) fn deprecates_proc_sets(&self) -> bool {

--- a/crates/krilla/src/document.rs
+++ b/crates/krilla/src/document.rs
@@ -125,4 +125,83 @@ impl Document {
 
         Ok(self.serializer_context.finish()?.finish())
     }
+
+    /// Attempt to export the document as PDF bytes, streaming them to a
+    /// [`std::io::Write`] sink instead of returning them as a `Vec<u8>`.
+    ///
+    /// Semantically, this produces the same PDF as [`Document::finish`] —
+    /// the byte stream written to `writer` is identical to the `Vec<u8>`
+    /// that `finish()` would return. Use this when you want to pipe the
+    /// output straight to a file, socket, pipe, or any other writer
+    /// without allocating the full document in memory first.
+    ///
+    /// # Errors
+    ///
+    /// Returns the usual [`KrillaError`] variants on serialization
+    /// failures, plus [`KrillaError::Io`] wrapping the underlying
+    /// [`io::Error`] message if the writer fails.
+    ///
+    /// [`KrillaError`]: crate::error::KrillaError
+    /// [`KrillaError::Io`]: crate::error::KrillaError::Io
+    /// [`io::Error`]: std::io::Error
+    pub fn finish_to_writer<W: std::io::Write>(mut self, mut writer: W) -> KrillaResult<()> {
+        // Write empty page if none has been created yet.
+        if self.serializer_context.page_infos().is_empty() {
+            self.start_page();
+        }
+
+        let bytes = self.serializer_context.finish()?.finish();
+        writer
+            .write_all(&bytes)
+            .map_err(|e| crate::error::KrillaError::Io(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two documents built identically must produce identical bytes whether
+    /// we call `finish()` (returning a Vec) or `finish_to_writer()`
+    /// (streaming into a Vec-as-writer).
+    #[test]
+    fn finish_to_writer_matches_finish() {
+        fn build() -> Document {
+            let mut doc = Document::new();
+            doc.start_page_with(PageSettings::from_wh(200.0, 150.0).expect("valid size"));
+            doc.start_page_with(PageSettings::from_wh(300.0, 200.0).expect("valid size"));
+            doc
+        }
+
+        let via_finish = build().finish().expect("finish");
+
+        let mut via_writer: Vec<u8> = Vec::new();
+        build()
+            .finish_to_writer(&mut via_writer)
+            .expect("finish_to_writer");
+
+        assert_eq!(via_finish, via_writer);
+    }
+
+    /// A writer that always fails must surface as `KrillaError::Io`.
+    #[test]
+    fn finish_to_writer_propagates_io_error() {
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "boom"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut doc = Document::new();
+        doc.start_page_with(PageSettings::from_wh(100.0, 100.0).expect("valid size"));
+
+        let err = doc
+            .finish_to_writer(FailingWriter)
+            .expect_err("should fail");
+        assert!(matches!(err, crate::error::KrillaError::Io(_)));
+    }
 }

--- a/crates/krilla/src/error.rs
+++ b/crates/krilla/src/error.rs
@@ -45,4 +45,9 @@ pub enum KrillaError {
     /// supported by the used PDF version (only available in PDF 1.5+).
     #[cfg(feature = "raster-images")]
     SixteenBitImage(Image, Option<Location>),
+    /// An I/O error occurred while streaming PDF output to a
+    /// [`std::io::Write`] sink (see [`Document::finish_to_writer`]).
+    ///
+    /// [`Document::finish_to_writer`]: crate::Document::finish_to_writer
+    Io(String),
 }


### PR DESCRIPTION
## Motivation

`Document::finish()` returns a `Vec<u8>` containing the full PDF bytes. For large documents (hundreds of pages, heavy tables, embedded images, etc.) this forces the caller to hold the entire serialized PDF in memory before it can be piped to a file, a socket, or any other sink.

We've hit this in a Typst fork that generates big tabular PDFs: we need the final byte stream to go straight to a file without materializing another copy of the entire document on the heap right before `write_all`.

## What this PR adds

1. **`Document::finish_to_writer<W: std::io::Write>(self, writer: W) -> KrillaResult<()>`**

   Same semantics as `finish()`, but writes into any `io::Write` sink instead of returning a `Vec<u8>`. The byte stream is byte-identical to what `finish()` would return.

   Call-site before:
   ```rust
   let bytes = doc.finish()?;
   std::fs::write("out.pdf", bytes)?;
   ```

   Call-site after:
   ```rust
   let file = std::fs::File::create("out.pdf")?;
   doc.finish_to_writer(file)?;
   ```

2. **`KrillaError::Io(String)`** — a new error variant that surfaces any `io::Error` raised by the writer.

3. **Small refactor in `PdfVersion`**: extract a private `version_tuple()` helper from `set_version()`, so a future internal streaming-serializer path can look up the `(major, minor)` pair without needing a `Pdf` instance to mutate.

The scope is deliberately narrow. Internally `finish_to_writer` currently forwards the result of `finish()` into `write_all`; the public API is the thing that's useful today, and a follow-up can make the internal writes truly streaming (so the full buffer is never materialized) without changing this entry point.

## Tests

Added two unit tests in `crates/krilla/src/document.rs`:

- `finish_to_writer_matches_finish` — builds two identical documents, finishes one via `finish()` and the other via `finish_to_writer` into a `Vec<u8>`, asserts the byte streams are equal.
- `finish_to_writer_propagates_io_error` — a `Write` impl that always returns `ErrorKind::BrokenPipe` surfaces as `KrillaError::Io`.

### Test plan
- [x] `cargo test -p krilla --lib document` passes.
- [x] `cargo clippy -p krilla --lib --all-features` clean under `-Dwarnings`.
- [x] `cargo fmt --check` clean.

Happy to split the refactor of `version_tuple` out if you'd prefer — it's only used by the streaming entry point right now, but the entry point doesn't strictly need it yet, so I can drop it if it feels like noise.