### PR TITLE
Properly enforce PDF 1.4 validation errors

### DIFF
--- a/crates/krilla-tests/src/pdf.rs
+++ b/crates/krilla-tests/src/pdf.rs
@@ -1,6 +1,6 @@
 use image::load_from_memory;
 use krilla::configure::{PdfVersion, ValidationError};
-use krilla::error::KrillaError;
+use krilla::error::{KrillaError, LimitError};
 use krilla::geom::{Size, Transform};
 use krilla::page::{Page, PageSettings};
 use krilla::pdf::PdfError;
@@ -13,7 +13,8 @@ use crate::metadata::metadata_impl;
 use crate::svg::sample_svg;
 use crate::text::simple_text_impl;
 use crate::{
-    load_pdf, load_png_image, loc, rect_to_path, red_fill, settings_16, settings_2, NOTO_SANS,
+    load_pdf, load_png_image, loc, rect_to_path, red_fill, settings_16, settings_17, settings_2,
+    youtube_link, NOTO_SANS,
 };
 
 #[snapshot(document)]
@@ -67,6 +68,19 @@ fn pdf_14_no_sixteen_bit_images() {
     assert_eq!(
         document.finish(),
         Err(KrillaError::SixteenBitImage(image.clone(), None))
+    );
+}
+
+#[test]
+fn pdf_14_unvalidated_version_limit_error() {
+    let mut document = Document::new_with(settings_17());
+    let mut page = document.start_page();
+    page.add_annotation(youtube_link(66000.1, 66000.1, 100.0, 100.0));
+    page.finish();
+
+    assert_eq!(
+        document.finish(),
+        Err(KrillaError::Limit(LimitError::TooLargeFloat))
     );
 }
 

--- a/crates/krilla/src/error.rs
+++ b/crates/krilla/src/error.rs
@@ -25,6 +25,8 @@ pub enum KrillaError {
     ///
     /// [`SerializeSettings`]: crate::SerializeSettings
     Validation(Vec<ValidationError>),
+    /// A hard limit of the selected PDF version was exceeded.
+    Limit(LimitError),
     /// A duplicate [`Tag::id`] was provided.
     ///
     /// [`Tag::id`]: crate::interchange::tagging::Tag::id
@@ -45,4 +47,15 @@ pub enum KrillaError {
     /// supported by the used PDF version (only available in PDF 1.5+).
     #[cfg(feature = "raster-images")]
     SixteenBitImage(Image, Option<Location>),
+}
+
+/// A limit imposed by the selected PDF version.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum LimitError {
+    /// A float exceeded the maximum allowed size for the PDF version.
+    TooLargeFloat,
+    /// An array exceeded the maximum allowed length for the PDF version.
+    TooLongArray,
+    /// A dictionary exceeded the maximum allowed number of entries for the PDF version.
+    TooLongDictionary,
 }

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -38,6 +38,8 @@ use crate::util::{Deferred, SipHashable};
 
 const STR_LEN: usize = 32767;
 const NAME_LEN: usize = 127;
+
+// These only apply to PDF 1.4 and PDF/A-1.
 const MAX_FLOAT: f32 = 32767.0;
 const DICT_LEN: usize = 4095;
 const ARRAY_LEN: usize = 8191;

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -14,7 +14,7 @@ use crate::chunk_container::{ChunkContainer, ChunkContainerFn};
 use crate::color::{CieBasedColorSpace, DeviceColorSpace, SpecialColorSpace};
 use crate::configure::validate::ValidationStore;
 use crate::configure::{Configuration, PdfVersion, ValidationError, Validator};
-use crate::error::{KrillaError, KrillaResult};
+use crate::error::{KrillaError, KrillaResult, LimitError};
 use crate::geom::Size;
 use crate::graphics::color::{rgb, ColorSpace};
 use crate::graphics::icc::{ICCBasedColorSpace, ICCProfile};
@@ -35,6 +35,12 @@ use crate::surface::{Location, Surface};
 use crate::text::GlyphId;
 use crate::text::{Font, FontContainer, FontIdentifier};
 use crate::util::{Deferred, SipHashable};
+
+const STR_LEN: usize = 32767;
+const NAME_LEN: usize = 127;
+const MAX_FLOAT: f32 = 32767.0;
+const DICT_LEN: usize = 4095;
+const ARRAY_LEN: usize = 8191;
 
 /// Settings that should be applied when creating a PDF document.
 #[derive(Clone, Debug)]
@@ -414,7 +420,7 @@ impl SerializeContext {
         };
         self.register_limits(pdf.limits());
 
-        self.check_limits();
+        self.check_validator_limits();
 
         if !self.validation_errors.is_empty() {
             // Deduplicate errors, while still preserving order.
@@ -429,6 +435,10 @@ impl SerializeContext {
             }
 
             return Err(KrillaError::Validation(errors));
+        }
+
+        if let Some(limit_error) = self.check_version_limits() {
+            return Err(KrillaError::Limit(limit_error));
         }
 
         // Just a sanity check that we've actually processed all items.
@@ -851,15 +861,7 @@ impl SerializeContext {
         Ok(())
     }
 
-    fn check_limits(&mut self) {
-        const STR_LEN: usize = 32767;
-        const NAME_LEN: usize = 127;
-
-        // These only apply to PDF 1.4 and PDF/A-1.
-        const MAX_FLOAT: f32 = 32767.0;
-        const DICT_LEN: usize = 4095;
-        const ARRAY_LEN: usize = 8191;
-
+    fn check_validator_limits(&mut self) {
         if self.cur_ref > Ref::new(8388607) {
             self.register_validation_error(ValidationError::TooManyIndirectObjects)
         }
@@ -883,6 +885,26 @@ impl SerializeContext {
         if self.limits.dict_entries() > DICT_LEN {
             self.register_validation_error(ValidationError::TooLongDictionary);
         }
+    }
+
+    fn check_version_limits(&self) -> Option<LimitError> {
+        if self.serialize_settings.pdf_version() != PdfVersion::Pdf14 {
+            return None;
+        }
+
+        if self.limits.real() > MAX_FLOAT {
+            return Some(LimitError::TooLargeFloat);
+        }
+
+        if self.limits.array_len() > ARRAY_LEN {
+            return Some(LimitError::TooLongArray);
+        }
+
+        if self.limits.dict_entries() > DICT_LEN {
+            return Some(LimitError::TooLongDictionary);
+        }
+
+        None
     }
 }
 


### PR DESCRIPTION
We have `ValidationError`, whose main purpose is to detect validation errors for specific substandards (PDF-A/1, PDF-UA, etc.). However, in those checks, we were also trying to enforce some of the PDF 1.4 specific limits. The problem is that if we export using PDF 1.4 but with no validator, those validations would actually not be triggered.

The solution to this is to additionally turn those validation errors into hard krilla errors. In case no validation error was triggered, we still check those limits in case we are exporting to PDF 1.4 and return an error if they apply.