### PR TITLE
Use single chunk for all struct elements

### DIFF
--- a/crates/krilla/src/chunk_container.rs
+++ b/crates/krilla/src/chunk_container.rs
@@ -24,7 +24,7 @@ pub(crate) struct ChunkContainer {
     pub(crate) destination_profiles: Option<(Ref, Chunk)>,
     pub(crate) struct_tree_root: Option<(Ref, Chunk)>,
 
-    pub(crate) struct_elements: Vec<Chunk>,
+    pub(crate) struct_elements: Option<Chunk>,
     pub(crate) page_labels: Vec<Chunk>,
     pub(crate) annotations: Vec<Chunk>,
     pub(crate) fonts: Vec<Chunk>,
@@ -365,6 +365,15 @@ impl Visit for ChunkContainer {
 impl Visit for Chunk {
     fn visit(&self, _: &mut SerializeContext, f: &mut impl FnMut(&Chunk)) -> KrillaResult<()> {
         f(self);
+        Ok(())
+    }
+}
+
+impl Visit for Option<Chunk> {
+    fn visit(&self, sc: &mut SerializeContext, f: &mut impl FnMut(&Chunk)) -> KrillaResult<()> {
+        if let Some(chunk) = self {
+            chunk.visit(sc, f)?;
+        }
         Ok(())
     }
 }

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -590,7 +590,7 @@ impl Node {
         id_tree: &mut BTreeMap<TagId, Ref>,
         parent: Ref,
         note_id: &mut u32,
-        struct_elems: &mut Vec<Chunk>,
+        struct_elems: &mut Chunk,
     ) -> KrillaResult<Option<Reference>> {
         match self {
             Node::Group(g) => Ok(Some(g.serialize(
@@ -665,7 +665,7 @@ impl TagGroup {
         id_tree: &mut BTreeMap<TagId, Ref>,
         parent_ref: Ref,
         note_id: &mut u32,
-        struct_elems: &mut Vec<Chunk>,
+        struct_elems: &mut Chunk,
     ) -> KrillaResult<Reference> {
         let elem_ref = sc.new_ref();
         let mut children_refs = vec![];
@@ -684,10 +684,7 @@ impl TagGroup {
             }
         }
 
-        // Note: Since we are going to be creating lots of these, we don't want
-        // to use the pdf-writer default of 1KB for the capacity.
-        let mut chunk = Chunk::with_capacity(128);
-        let mut struct_elem = chunk.struct_element(elem_ref);
+        let mut struct_elem = struct_elems.struct_element(elem_ref);
         self.tag.write_kind(&mut struct_elem, sc);
         struct_elem.parent(parent_ref);
 
@@ -970,7 +967,6 @@ impl TagGroup {
             &mut struct_elem,
         )?;
         struct_elem.finish();
-        struct_elems.push(chunk);
 
         Ok(Reference::Ref(elem_ref))
     }
@@ -1041,9 +1037,9 @@ impl TagTree {
         parent_tree_map: &mut HashMap<IdentifierType, Ref>,
         id_tree_map: &mut BTreeMap<TagId, Ref>,
         struct_tree_ref: Ref,
-    ) -> KrillaResult<(Ref, Vec<Chunk>)> {
+    ) -> KrillaResult<(Ref, Chunk)> {
         let root_ref = sc.new_ref();
-        let mut struct_elems = vec![];
+        let mut struct_elems = Chunk::new();
 
         // Keeps track of the ID of notes in the IDTree. We currently only write IDs for notes,
         // which is why we use this simple variable, but this should be refactored if we write
@@ -1067,8 +1063,7 @@ impl TagTree {
             }
         }
 
-        let mut chunk = Chunk::new();
-        let mut struct_elem = chunk.indirect(root_ref).start::<StructElement>();
+        let mut struct_elem = struct_elems.indirect(root_ref).start::<StructElement>();
         struct_elem.kind(StructRole::Document);
         struct_elem.parent(struct_tree_ref);
         if let Some(lang) = &self.lang {
@@ -1085,11 +1080,6 @@ impl TagTree {
         )?;
 
         struct_elem.finish();
-        struct_elems.push(chunk);
-
-        // Not strictly necessary, but it's nicer to have them in DFS-order instead
-        // of in reverse.
-        struct_elems = struct_elems.into_iter().rev().collect::<Vec<_>>();
 
         Ok((root_ref, struct_elems))
     }

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -756,7 +756,7 @@ impl SerializeContext {
                 &mut id_tree_map,
                 struct_tree_root_ref,
             )?;
-            self.chunk_container.struct_elements = vec![struct_elems];
+            self.chunk_container.struct_elements = Some(struct_elems);
 
             root.validate(&id_tree_map)?;
 

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -756,7 +756,7 @@ impl SerializeContext {
                 &mut id_tree_map,
                 struct_tree_root_ref,
             )?;
-            self.chunk_container.struct_elements = struct_elems;
+            self.chunk_container.struct_elements = vec![struct_elems];
 
             root.validate(&id_tree_map)?;
 

--- a/refs/snapshots/tagging_custom_namespace_pdf_20.txt
+++ b/refs/snapshots/tagging_custom_namespace_pdf_20.txt
@@ -13,7 +13,7 @@ endobj
 <<
   /Type /StructTreeRoot
   /Namespaces [3 0 R 4 0 R]
-  /K [5 0 R]
+  /K [7 0 R]
 >>
 endobj
 
@@ -38,9 +38,10 @@ endobj
 5 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [6 0 R]
+  /S /Span
+  /NS 3 0 R
+  /P 6 0 R
+  /K []
 >>
 endobj
 
@@ -49,18 +50,17 @@ endobj
   /Type /StructElem
   /S /Datetime
   /NS 4 0 R
-  /P 5 0 R
-  /K [7 0 R]
+  /P 7 0 R
+  /K [5 0 R]
 >>
 endobj
 
 7 0 obj
 <<
   /Type /StructElem
-  /S /Span
-  /NS 3 0 R
-  /P 6 0 R
-  /K []
+  /S /Document
+  /P 2 0 R
+  /K [6 0 R]
 >>
 endobj
 
@@ -111,8 +111,8 @@ xref
 0000000167 00000 n
 0000000245 00000 n
 0000000403 00000 n
-0000000484 00000 n
-0000000577 00000 n
+0000000487 00000 n
+0000000580 00000 n
 0000000661 00000 n
 0000000775 00000 n
 0000000894 00000 n
@@ -120,7 +120,7 @@ trailer
 <<
   /Size 11
   /Root 10 0 R
-  /ID [(c03RIEfJBtxaKvqukY7BjA==) (c03RIEfJBtxaKvqukY7BjA==)]
+  /ID [(y6mrL+D1AkY/9ofkQJ7VlA==) (y6mrL+D1AkY/9ofkQJ7VlA==)]
 >>
 startxref
 1010

--- a/refs/snapshots/tagging_div_and_border_color.txt
+++ b/refs/snapshots/tagging_div_and_border_color.txt
@@ -25,7 +25,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [5 0 R]
+  /K [7 0 R]
   /ParentTree <<
     /Nums [0 4 0 R]
   >>
@@ -34,15 +34,16 @@ endobj
 endobj
 
 4 0 obj
-[7 0 R]
+[5 0 R]
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 3 0 R
-  /K [6 0 R]
+  /S /P
+  /P 6 0 R
+  /K [0]
+  /Pg 14 0 R
 >>
 endobj
 
@@ -50,24 +51,23 @@ endobj
 <<
   /Type /StructElem
   /S /Div
-  /P 5 0 R
+  /P 7 0 R
   /A [<<
     /O /Layout
     /BorderColor [[1 0 0] [0 0 1] [1 0 0] [0 0 1]]
     /ColumnCount 2
     /ColumnWidths 50
   >>]
-  /K [7 0 R]
+  /K [5 0 R]
 >>
 endobj
 
 7 0 obj
 <<
   /Type /StructElem
-  /S /P
-  /P 6 0 R
-  /K [0]
-  /Pg 14 0 R
+  /S /Document
+  /P 3 0 R
+  /K [6 0 R]
 >>
 endobj
 
@@ -280,7 +280,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Tagged Borders</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>HzT3Ez9/e9U7+dhnTIO+IQ==</xmpMM:InstanceID><xmpMM:DocumentID>HzT3Ez9/e9U7+dhnTIO+IQ==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Tagged Borders</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>TYmLBI6bYWh+nrTWXxfvaQ==</xmpMM:InstanceID><xmpMM:DocumentID>TYmLBI6bYWh+nrTWXxfvaQ==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -310,8 +310,8 @@ xref
 0000000121 00000 n
 0000000347 00000 n
 0000000371 00000 n
-0000000452 00000 n
-0000000649 00000 n
+0000000454 00000 n
+0000000651 00000 n
 0000000732 00000 n
 0000000894 00000 n
 0000001247 00000 n
@@ -328,7 +328,7 @@ trailer
   /Size 19
   /Root 18 0 R
   /Info 16 0 R
-  /ID [(HzT3Ez9/e9U7+dhnTIO+IQ==) (HzT3Ez9/e9U7+dhnTIO+IQ==)]
+  /ID [(TYmLBI6bYWh+nrTWXxfvaQ==) (TYmLBI6bYWh+nrTWXxfvaQ==)]
 >>
 startxref
 7464

--- a/refs/snapshots/tagging_empty_table_cell_headers.txt
+++ b/refs/snapshots/tagging_empty_table_cell_headers.txt
@@ -19,7 +19,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [4 0 R]
+  /K [9 0 R]
   /ParentTree <<
     /Nums [0 3 0 R]
   >>
@@ -28,41 +28,37 @@ endobj
 endobj
 
 3 0 obj
-[9 0 R 7 0 R]
+[4 0 R 6 0 R]
 endobj
 
 4 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [5 0 R]
+  /S /TH
+  /P 5 0 R
+  /A [<<
+    /O /Table
+    /Scope /Column
+  >>]
+  /K [0]
+  /Pg 16 0 R
 >>
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Table
-  /P 4 0 R
-  /K [8 0 R 6 0 R]
+  /S /TR
+  /P 8 0 R
+  /K [4 0 R]
 >>
 endobj
 
 6 0 obj
 <<
   /Type /StructElem
-  /S /TR
-  /P 5 0 R
-  /K [7 0 R]
->>
-endobj
-
-7 0 obj
-<<
-  /Type /StructElem
   /S /TD
-  /P 6 0 R
+  /P 7 0 R
   /A [<<
     /O /Table
     /Headers []
@@ -72,26 +68,30 @@ endobj
 >>
 endobj
 
-8 0 obj
+7 0 obj
 <<
   /Type /StructElem
   /S /TR
-  /P 5 0 R
-  /K [9 0 R]
+  /P 8 0 R
+  /K [6 0 R]
+>>
+endobj
+
+8 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 9 0 R
+  /K [5 0 R 7 0 R]
 >>
 endobj
 
 9 0 obj
 <<
   /Type /StructElem
-  /S /TH
-  /P 8 0 R
-  /A [<<
-    /O /Table
-    /Scope /Column
-  >>]
-  /K [0]
-  /Pg 16 0 R
+  /S /Document
+  /P 2 0 R
+  /K [8 0 R]
 >>
 endobj
 
@@ -308,11 +308,11 @@ xref
 0000000081 00000 n
 0000000307 00000 n
 0000000337 00000 n
-0000000418 00000 n
-0000000502 00000 n
-0000000577 00000 n
-0000000706 00000 n
-0000000781 00000 n
+0000000469 00000 n
+0000000544 00000 n
+0000000673 00000 n
+0000000748 00000 n
+0000000832 00000 n
 0000000913 00000 n
 0000001077 00000 n
 0000001379 00000 n
@@ -326,7 +326,7 @@ trailer
 <<
   /Size 19
   /Root 18 0 R
-  /ID [(0482B7EzKkJLUSkoSmJ1pQ==) (0482B7EzKkJLUSkoSmJ1pQ==)]
+  /ID [(1lCOvFYDyXP2/5rUPM5xow==) (1lCOvFYDyXP2/5rUPM5xow==)]
 >>
 startxref
 5656

--- a/refs/snapshots/tagging_figure_bounds.txt
+++ b/refs/snapshots/tagging_figure_bounds.txt
@@ -25,7 +25,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [5 0 R]
+  /K [7 0 R]
   /ParentTree <<
     /Nums [0 4 0 R]
   >>
@@ -34,28 +34,10 @@ endobj
 endobj
 
 4 0 obj
-[7 0 R]
+[5 0 R]
 endobj
 
 5 0 obj
-<<
-  /Type /StructElem
-  /S /Document
-  /P 3 0 R
-  /K [6 0 R]
->>
-endobj
-
-6 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 5 0 R
-  /K [7 0 R]
->>
-endobj
-
-7 0 obj
 <<
   /Type /StructElem
   /S /Figure
@@ -69,6 +51,24 @@ endobj
   >>]
   /K [0]
   /Pg 8 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 7 0 R
+  /K [5 0 R]
+>>
+endobj
+
+7 0 obj
+<<
+  /Type /StructElem
+  /S /Document
+  /P 3 0 R
+  /K [6 0 R]
 >>
 endobj
 
@@ -168,7 +168,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Figure</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>DN87oAO8qS5Ey+0JlAQIow==</xmpMM:InstanceID><xmpMM:DocumentID>DN87oAO8qS5Ey+0JlAQIow==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Figure</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>IKyXZrJggIURt4mlbXYT3A==</xmpMM:InstanceID><xmpMM:DocumentID>IKyXZrJggIURt4mlbXYT3A==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -198,8 +198,8 @@ xref
 0000000120 00000 n
 0000000346 00000 n
 0000000370 00000 n
-0000000451 00000 n
-0000000525 00000 n
+0000000566 00000 n
+0000000640 00000 n
 0000000721 00000 n
 0000000939 00000 n
 0000001052 00000 n
@@ -211,7 +211,7 @@ trailer
   /Size 14
   /Root 13 0 R
   /Info 11 0 R
-  /ID [(DN87oAO8qS5Ey+0JlAQIow==) (DN87oAO8qS5Ey+0JlAQIow==)]
+  /ID [(IKyXZrJggIURt4mlbXYT3A==) (IKyXZrJggIURt4mlbXYT3A==)]
 >>
 startxref
 5129

--- a/refs/snapshots/tagging_heading_level_7_and_8_pdf_17.txt
+++ b/refs/snapshots/tagging_heading_level_7_and_8_pdf_17.txt
@@ -21,7 +21,7 @@ endobj
     /H7 /P
     /H8 /P
   >>
-  /K [4 0 R]
+  /K [20 0 R]
   /ParentTree <<
     /Nums [0 3 0 R]
   >>
@@ -30,91 +30,87 @@ endobj
 endobj
 
 3 0 obj
-[20 0 R 19 0 R 18 0 R 17 0 R 16 0 R 15 0 R 14 0 R 13 0 R]
+[4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R]
 endobj
 
 4 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [5 0 R]
+  /S /H1
+  /P 19 0 R
+  /T (first heading)
+  /K [0]
+  /Pg 27 0 R
 >>
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Sect
-  /P 4 0 R
-  /K [20 0 R 6 0 R]
+  /S /H2
+  /P 18 0 R
+  /T (second heading)
+  /K [1]
+  /Pg 27 0 R
 >>
 endobj
 
 6 0 obj
 <<
   /Type /StructElem
-  /S /Sect
-  /P 5 0 R
-  /K [19 0 R 7 0 R]
+  /S /H3
+  /P 17 0 R
+  /T (third heading)
+  /K [2]
+  /Pg 27 0 R
 >>
 endobj
 
 7 0 obj
 <<
   /Type /StructElem
-  /S /Sect
-  /P 6 0 R
-  /K [18 0 R 8 0 R]
+  /S /H4
+  /P 16 0 R
+  /T (fourth heading)
+  /K [3]
+  /Pg 27 0 R
 >>
 endobj
 
 8 0 obj
 <<
   /Type /StructElem
-  /S /Sect
-  /P 7 0 R
-  /K [17 0 R 9 0 R]
+  /S /H5
+  /P 15 0 R
+  /T (fifth heading)
+  /K [4]
+  /Pg 27 0 R
 >>
 endobj
 
 9 0 obj
 <<
   /Type /StructElem
-  /S /Sect
-  /P 8 0 R
-  /K [16 0 R 10 0 R]
+  /S /H6
+  /P 14 0 R
+  /T (sixth heading)
+  /K [5]
+  /Pg 27 0 R
 >>
 endobj
 
 10 0 obj
 <<
   /Type /StructElem
-  /S /Sect
-  /P 9 0 R
-  /K [15 0 R 11 0 R]
+  /S /H7
+  /P 13 0 R
+  /T (senventh heading)
+  /K [6]
+  /Pg 27 0 R
 >>
 endobj
 
 11 0 obj
-<<
-  /Type /StructElem
-  /S /Sect
-  /P 10 0 R
-  /K [14 0 R 12 0 R]
->>
-endobj
-
-12 0 obj
-<<
-  /Type /StructElem
-  /S /Sect
-  /P 11 0 R
-  /K [13 0 R]
->>
-endobj
-
-13 0 obj
 <<
   /Type /StructElem
   /S /H8
@@ -125,80 +121,84 @@ endobj
 >>
 endobj
 
+12 0 obj
+<<
+  /Type /StructElem
+  /S /Sect
+  /P 13 0 R
+  /K [11 0 R]
+>>
+endobj
+
+13 0 obj
+<<
+  /Type /StructElem
+  /S /Sect
+  /P 14 0 R
+  /K [10 0 R 12 0 R]
+>>
+endobj
+
 14 0 obj
 <<
   /Type /StructElem
-  /S /H7
-  /P 11 0 R
-  /T (senventh heading)
-  /K [6]
-  /Pg 27 0 R
+  /S /Sect
+  /P 15 0 R
+  /K [9 0 R 13 0 R]
 >>
 endobj
 
 15 0 obj
 <<
   /Type /StructElem
-  /S /H6
-  /P 10 0 R
-  /T (sixth heading)
-  /K [5]
-  /Pg 27 0 R
+  /S /Sect
+  /P 16 0 R
+  /K [8 0 R 14 0 R]
 >>
 endobj
 
 16 0 obj
 <<
   /Type /StructElem
-  /S /H5
-  /P 9 0 R
-  /T (fifth heading)
-  /K [4]
-  /Pg 27 0 R
+  /S /Sect
+  /P 17 0 R
+  /K [7 0 R 15 0 R]
 >>
 endobj
 
 17 0 obj
 <<
   /Type /StructElem
-  /S /H4
-  /P 8 0 R
-  /T (fourth heading)
-  /K [3]
-  /Pg 27 0 R
+  /S /Sect
+  /P 18 0 R
+  /K [6 0 R 16 0 R]
 >>
 endobj
 
 18 0 obj
 <<
   /Type /StructElem
-  /S /H3
-  /P 7 0 R
-  /T (third heading)
-  /K [2]
-  /Pg 27 0 R
+  /S /Sect
+  /P 19 0 R
+  /K [5 0 R 17 0 R]
 >>
 endobj
 
 19 0 obj
 <<
   /Type /StructElem
-  /S /H2
-  /P 6 0 R
-  /T (second heading)
-  /K [1]
-  /Pg 27 0 R
+  /S /Sect
+  /P 20 0 R
+  /K [4 0 R 18 0 R]
 >>
 endobj
 
 20 0 obj
 <<
   /Type /StructElem
-  /S /H1
-  /P 5 0 R
-  /T (first heading)
-  /K [0]
-  /Pg 27 0 R
+  /S /Document
+  /P 2 0 R
+  /K [19 0 R]
 >>
 endobj
 
@@ -532,39 +532,39 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000081 00000 n
-0000000329 00000 n
-0000000403 00000 n
-0000000484 00000 n
-0000000568 00000 n
-0000000652 00000 n
-0000000736 00000 n
-0000000820 00000 n
-0000000905 00000 n
-0000000991 00000 n
-0000001078 00000 n
-0000001158 00000 n
-0000001265 00000 n
-0000001375 00000 n
-0000001482 00000 n
-0000001588 00000 n
-0000001695 00000 n
-0000001801 00000 n
-0000001908 00000 n
-0000002014 00000 n
-0000002178 00000 n
-0000002608 00000 n
-0000002725 00000 n
-0000002970 00000 n
-0000003912 00000 n
-0000007932 00000 n
-0000008149 00000 n
-0000009809 00000 n
+0000000330 00000 n
+0000000398 00000 n
+0000000504 00000 n
+0000000611 00000 n
+0000000717 00000 n
+0000000824 00000 n
+0000000930 00000 n
+0000001036 00000 n
+0000001146 00000 n
+0000001253 00000 n
+0000001333 00000 n
+0000001420 00000 n
+0000001506 00000 n
+0000001592 00000 n
+0000001678 00000 n
+0000001764 00000 n
+0000001850 00000 n
+0000001936 00000 n
+0000002019 00000 n
+0000002183 00000 n
+0000002613 00000 n
+0000002730 00000 n
+0000002975 00000 n
+0000003917 00000 n
+0000007937 00000 n
+0000008154 00000 n
+0000009814 00000 n
 trailer
 <<
   /Size 30
   /Root 29 0 R
-  /ID [(8aZKFl+cUUAvLB0cIV8Okg==) (8aZKFl+cUUAvLB0cIV8Okg==)]
+  /ID [(uzyxkMI6VGgvlZlP0lODLw==) (uzyxkMI6VGgvlZlP0lODLw==)]
 >>
 startxref
-9945
+9950
 %%EOF

--- a/refs/snapshots/tagging_heading_level_7_and_8_pdf_20.txt
+++ b/refs/snapshots/tagging_heading_level_7_and_8_pdf_20.txt
@@ -13,7 +13,7 @@ endobj
 <<
   /Type /StructTreeRoot
   /Namespaces [3 0 R 4 0 R]
-  /K [6 0 R]
+  /K [22 0 R]
   /ParentTree <<
     /Nums [0 5 0 R]
   >>
@@ -40,99 +40,94 @@ endobj
 endobj
 
 5 0 obj
-[22 0 R 21 0 R 20 0 R 19 0 R 18 0 R 17 0 R 16 0 R 15 0 R]
+[6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R]
 endobj
 
 6 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [7 0 R]
+  /S /H1
+  /NS 3 0 R
+  /P 21 0 R
+  /T (first heading)
+  /K [0]
+  /Pg 28 0 R
 >>
 endobj
 
 7 0 obj
 <<
   /Type /StructElem
-  /S /Sect
+  /S /H2
   /NS 3 0 R
-  /P 6 0 R
-  /K [22 0 R 8 0 R]
+  /P 20 0 R
+  /T (second heading)
+  /K [1]
+  /Pg 28 0 R
 >>
 endobj
 
 8 0 obj
 <<
   /Type /StructElem
-  /S /Sect
+  /S /H3
   /NS 3 0 R
-  /P 7 0 R
-  /K [21 0 R 9 0 R]
+  /P 19 0 R
+  /T (third heading)
+  /K [2]
+  /Pg 28 0 R
 >>
 endobj
 
 9 0 obj
 <<
   /Type /StructElem
-  /S /Sect
+  /S /H4
   /NS 3 0 R
-  /P 8 0 R
-  /K [20 0 R 10 0 R]
+  /P 18 0 R
+  /T (fourth heading)
+  /K [3]
+  /Pg 28 0 R
 >>
 endobj
 
 10 0 obj
 <<
   /Type /StructElem
-  /S /Sect
+  /S /H5
   /NS 3 0 R
-  /P 9 0 R
-  /K [19 0 R 11 0 R]
+  /P 17 0 R
+  /T (fifth heading)
+  /K [4]
+  /Pg 28 0 R
 >>
 endobj
 
 11 0 obj
 <<
   /Type /StructElem
-  /S /Sect
+  /S /H6
   /NS 3 0 R
-  /P 10 0 R
-  /K [18 0 R 12 0 R]
+  /P 16 0 R
+  /T (sixth heading)
+  /K [5]
+  /Pg 28 0 R
 >>
 endobj
 
 12 0 obj
 <<
   /Type /StructElem
-  /S /Sect
+  /S /H7
   /NS 3 0 R
-  /P 11 0 R
-  /K [17 0 R 13 0 R]
+  /P 15 0 R
+  /T (senventh heading)
+  /K [6]
+  /Pg 28 0 R
 >>
 endobj
 
 13 0 obj
-<<
-  /Type /StructElem
-  /S /Sect
-  /NS 3 0 R
-  /P 12 0 R
-  /K [16 0 R 14 0 R]
->>
-endobj
-
-14 0 obj
-<<
-  /Type /StructElem
-  /S /Sect
-  /NS 3 0 R
-  /P 13 0 R
-  /K [15 0 R]
->>
-endobj
-
-15 0 obj
 <<
   /Type /StructElem
   /S /H8
@@ -144,87 +139,92 @@ endobj
 >>
 endobj
 
+14 0 obj
+<<
+  /Type /StructElem
+  /S /Sect
+  /NS 3 0 R
+  /P 15 0 R
+  /K [13 0 R]
+>>
+endobj
+
+15 0 obj
+<<
+  /Type /StructElem
+  /S /Sect
+  /NS 3 0 R
+  /P 16 0 R
+  /K [12 0 R 14 0 R]
+>>
+endobj
+
 16 0 obj
 <<
   /Type /StructElem
-  /S /H7
+  /S /Sect
   /NS 3 0 R
-  /P 13 0 R
-  /T (senventh heading)
-  /K [6]
-  /Pg 28 0 R
+  /P 17 0 R
+  /K [11 0 R 15 0 R]
 >>
 endobj
 
 17 0 obj
 <<
   /Type /StructElem
-  /S /H6
+  /S /Sect
   /NS 3 0 R
-  /P 12 0 R
-  /T (sixth heading)
-  /K [5]
-  /Pg 28 0 R
+  /P 18 0 R
+  /K [10 0 R 16 0 R]
 >>
 endobj
 
 18 0 obj
 <<
   /Type /StructElem
-  /S /H5
+  /S /Sect
   /NS 3 0 R
-  /P 11 0 R
-  /T (fifth heading)
-  /K [4]
-  /Pg 28 0 R
+  /P 19 0 R
+  /K [9 0 R 17 0 R]
 >>
 endobj
 
 19 0 obj
 <<
   /Type /StructElem
-  /S /H4
+  /S /Sect
   /NS 3 0 R
-  /P 10 0 R
-  /T (fourth heading)
-  /K [3]
-  /Pg 28 0 R
+  /P 20 0 R
+  /K [8 0 R 18 0 R]
 >>
 endobj
 
 20 0 obj
 <<
   /Type /StructElem
-  /S /H3
+  /S /Sect
   /NS 3 0 R
-  /P 9 0 R
-  /T (third heading)
-  /K [2]
-  /Pg 28 0 R
+  /P 21 0 R
+  /K [7 0 R 19 0 R]
 >>
 endobj
 
 21 0 obj
 <<
   /Type /StructElem
-  /S /H2
+  /S /Sect
   /NS 3 0 R
-  /P 8 0 R
-  /T (second heading)
-  /K [1]
-  /Pg 28 0 R
+  /P 22 0 R
+  /K [6 0 R 20 0 R]
 >>
 endobj
 
 22 0 obj
 <<
   /Type /StructElem
-  /S /H1
-  /NS 3 0 R
-  /P 7 0 R
-  /T (first heading)
-  /K [0]
-  /Pg 28 0 R
+  /S /Document
+  /P 2 0 R
+  /K [21 0 R]
 >>
 endobj
 
@@ -545,40 +545,40 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000081 00000 n
-0000000233 00000 n
-0000000311 00000 n
-0000000469 00000 n
-0000000543 00000 n
-0000000624 00000 n
-0000000720 00000 n
-0000000816 00000 n
-0000000913 00000 n
-0000001011 00000 n
-0000001110 00000 n
-0000001209 00000 n
-0000001308 00000 n
-0000001400 00000 n
-0000001519 00000 n
-0000001641 00000 n
-0000001760 00000 n
-0000001879 00000 n
-0000001999 00000 n
-0000002117 00000 n
-0000002236 00000 n
-0000002354 00000 n
-0000002518 00000 n
-0000002948 00000 n
-0000003176 00000 n
-0000004118 00000 n
-0000008138 00000 n
-0000008313 00000 n
-0000009973 00000 n
+0000000234 00000 n
+0000000312 00000 n
+0000000470 00000 n
+0000000540 00000 n
+0000000658 00000 n
+0000000777 00000 n
+0000000895 00000 n
+0000001014 00000 n
+0000001133 00000 n
+0000001252 00000 n
+0000001374 00000 n
+0000001493 00000 n
+0000001585 00000 n
+0000001684 00000 n
+0000001783 00000 n
+0000001882 00000 n
+0000001980 00000 n
+0000002078 00000 n
+0000002176 00000 n
+0000002274 00000 n
+0000002357 00000 n
+0000002521 00000 n
+0000002951 00000 n
+0000003179 00000 n
+0000004121 00000 n
+0000008141 00000 n
+0000008316 00000 n
+0000009976 00000 n
 trailer
 <<
   /Size 31
   /Root 30 0 R
-  /ID [(/MHxNrXmNr1g2aV3ptZ2Mg==) (/MHxNrXmNr1g2aV3ptZ2Mg==)]
+  /ID [(pon9TYBGxPYngZByRcfnjA==) (pon9TYBGxPYngZByRcfnjA==)]
 >>
 startxref
-10089
+10092
 %%EOF

--- a/refs/snapshots/tagging_image_with_alt.txt
+++ b/refs/snapshots/tagging_image_with_alt.txt
@@ -19,7 +19,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [4 0 R]
+  /K [5 0 R]
   /ParentTree <<
     /Nums [0 3 0 R]
   >>
@@ -28,26 +28,26 @@ endobj
 endobj
 
 3 0 obj
-[5 0 R]
+[4 0 R]
 endobj
 
 4 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [5 0 R]
+  /S /Figure
+  /P 5 0 R
+  /Alt (This is the alternate text.)
+  /K [0]
+  /Pg 6 0 R
 >>
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Figure
-  /P 4 0 R
-  /Alt (This is the alternate text.)
-  /K [0]
-  /Pg 6 0 R
+  /S /Document
+  /P 2 0 R
+  /K [4 0 R]
 >>
 endobj
 
@@ -134,7 +134,7 @@ xref
 0000000080 00000 n
 0000000306 00000 n
 0000000330 00000 n
-0000000411 00000 n
+0000000454 00000 n
 0000000535 00000 n
 0000000713 00000 n
 0000001053 00000 n
@@ -142,7 +142,7 @@ trailer
 <<
   /Size 9
   /Root 8 0 R
-  /ID [(XEzNKNFL1VGVmjCbaAX62Q==) (XEzNKNFL1VGVmjCbaAX62Q==)]
+  /ID [(0K/+PjSEmJIsiA6maibLuA==) (0K/+PjSEmJIsiA6maibLuA==)]
 >>
 startxref
 1188

--- a/refs/snapshots/tagging_layout_placement_and_writing_mode.txt
+++ b/refs/snapshots/tagging_layout_placement_and_writing_mode.txt
@@ -25,7 +25,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [5 0 R]
+  /K [7 0 R]
   /ParentTree <<
     /Nums [0 4 0 R]
   >>
@@ -34,33 +34,10 @@ endobj
 endobj
 
 4 0 obj
-[7 0 R]
+[5 0 R]
 endobj
 
 5 0 obj
-<<
-  /Type /StructElem
-  /S /Document
-  /P 3 0 R
-  /K [6 0 R]
->>
-endobj
-
-6 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 5 0 R
-  /A [<<
-    /O /Layout
-    /Placement /Block
-    /WritingMode /LrTb
-  >>]
-  /K [7 0 R]
->>
-endobj
-
-7 0 obj
 <<
   /Type /StructElem
   /S /Quote
@@ -71,6 +48,29 @@ endobj
   >>]
   /K [0]
   /Pg 14 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 7 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+    /WritingMode /LrTb
+  >>]
+  /K [5 0 R]
+>>
+endobj
+
+7 0 obj
+<<
+  /Type /StructElem
+  /S /Document
+  /P 3 0 R
+  /K [6 0 R]
 >>
 endobj
 
@@ -283,7 +283,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Layout</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>cjYQdMb5VzzHm8MBuqNLnw==</xmpMM:InstanceID><xmpMM:DocumentID>cjYQdMb5VzzHm8MBuqNLnw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Layout</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>5i+IX93jLeuWtXwZqsOeBQ==</xmpMM:InstanceID><xmpMM:DocumentID>5i+IX93jLeuWtXwZqsOeBQ==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -313,8 +313,8 @@ xref
 0000000121 00000 n
 0000000347 00000 n
 0000000371 00000 n
-0000000452 00000 n
-0000000601 00000 n
+0000000511 00000 n
+0000000660 00000 n
 0000000741 00000 n
 0000000903 00000 n
 0000001256 00000 n
@@ -331,7 +331,7 @@ trailer
   /Size 19
   /Root 18 0 R
   /Info 16 0 R
-  /ID [(cjYQdMb5VzzHm8MBuqNLnw==) (cjYQdMb5VzzHm8MBuqNLnw==)]
+  /ID [(5i+IX93jLeuWtXwZqsOeBQ==) (5i+IX93jLeuWtXwZqsOeBQ==)]
 >>
 startxref
 7457

--- a/refs/snapshots/tagging_multiple_pages.txt
+++ b/refs/snapshots/tagging_multiple_pages.txt
@@ -19,7 +19,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [6 0 R]
+  /K [12 0 R]
   /ParentTree <<
     /Nums [0 3 0 R 1 4 0 R 2 5 0 R]
   >>
@@ -28,70 +28,33 @@ endobj
 endobj
 
 3 0 obj
-[12 0 R 11 0 R]
+[6 0 R 7 0 R]
 endobj
 
 4 0 obj
-[11 0 R]
+[7 0 R]
 endobj
 
 5 0 obj
-[9 0 R 8 0 R]
+[9 0 R 10 0 R]
 endobj
 
 6 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [10 0 R 7 0 R]
+  /S /H1
+  /P 8 0 R
+  /T (first heading)
+  /K [0]
+  /Pg 19 0 R
 >>
 endobj
 
 7 0 obj
 <<
   /Type /StructElem
-  /S /Sect
-  /P 6 0 R
-  /K [9 0 R 8 0 R]
->>
-endobj
-
-8 0 obj
-<<
-  /Type /StructElem
   /S /P
-  /P 7 0 R
-  /K [1]
-  /Pg 23 0 R
->>
-endobj
-
-9 0 obj
-<<
-  /Type /StructElem
-  /S /H1
-  /P 7 0 R
-  /T (second heading)
-  /K [0]
-  /Pg 23 0 R
->>
-endobj
-
-10 0 obj
-<<
-  /Type /StructElem
-  /S /Sect
-  /P 6 0 R
-  /K [12 0 R 11 0 R]
->>
-endobj
-
-11 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 10 0 R
+  /P 8 0 R
   /K [1 <<
     /Type /MCR
     /MCID 0
@@ -101,14 +64,51 @@ endobj
 >>
 endobj
 
-12 0 obj
+8 0 obj
+<<
+  /Type /StructElem
+  /S /Sect
+  /P 12 0 R
+  /K [6 0 R 7 0 R]
+>>
+endobj
+
+9 0 obj
 <<
   /Type /StructElem
   /S /H1
-  /P 10 0 R
-  /T (first heading)
+  /P 11 0 R
+  /T (second heading)
   /K [0]
-  /Pg 19 0 R
+  /Pg 23 0 R
+>>
+endobj
+
+10 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 11 0 R
+  /K [1]
+  /Pg 23 0 R
+>>
+endobj
+
+11 0 obj
+<<
+  /Type /StructElem
+  /S /Sect
+  /P 12 0 R
+  /K [9 0 R 10 0 R]
+>>
+endobj
+
+12 0 obj
+<<
+  /Type /StructElem
+  /S /Document
+  /P 2 0 R
+  /K [8 0 R 11 0 R]
 >>
 endobj
 
@@ -439,16 +439,16 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000095 00000 n
-0000000337 00000 n
-0000000369 00000 n
-0000000394 00000 n
-0000000424 00000 n
-0000000512 00000 n
-0000000595 00000 n
-0000000678 00000 n
-0000000784 00000 n
-0000000870 00000 n
-0000001005 00000 n
+0000000338 00000 n
+0000000368 00000 n
+0000000392 00000 n
+0000000423 00000 n
+0000000528 00000 n
+0000000661 00000 n
+0000000745 00000 n
+0000000852 00000 n
+0000000937 00000 n
+0000001023 00000 n
 0000001112 00000 n
 0000001276 00000 n
 0000001652 00000 n
@@ -466,7 +466,7 @@ trailer
 <<
   /Size 26
   /Root 25 0 R
-  /ID [(kBnGIrl99FjESboXDhmyWA==) (kBnGIrl99FjESboXDhmyWA==)]
+  /ID [(KlXBlo6xyWg0Z1n49qQX6A==) (KlXBlo6xyWg0Z1n49qQX6A==)]
 >>
 startxref
 8587

--- a/refs/snapshots/tagging_simple.txt
+++ b/refs/snapshots/tagging_simple.txt
@@ -19,7 +19,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [4 0 R]
+  /K [5 0 R]
   /ParentTree <<
     /Nums [0 3 0 R]
   >>
@@ -28,25 +28,25 @@ endobj
 endobj
 
 3 0 obj
-[5 0 R]
+[4 0 R]
 endobj
 
 4 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [5 0 R]
+  /S /P
+  /P 5 0 R
+  /K [0]
+  /Pg 12 0 R
 >>
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /P
-  /P 4 0 R
-  /K [0]
-  /Pg 12 0 R
+  /S /Document
+  /P 2 0 R
+  /K [4 0 R]
 >>
 endobj
 
@@ -254,7 +254,7 @@ xref
 0000000081 00000 n
 0000000307 00000 n
 0000000331 00000 n
-0000000412 00000 n
+0000000414 00000 n
 0000000495 00000 n
 0000000657 00000 n
 0000000965 00000 n
@@ -268,7 +268,7 @@ trailer
 <<
   /Size 15
   /Root 14 0 R
-  /ID [(/F7frA58wD7MlL03RMibjA==) (/F7frA58wD7MlL03RMibjA==)]
+  /ID [(CteGGSYfusiYDdCZOukjCA==) (CteGGSYfusiYDdCZOukjCA==)]
 >>
 startxref
 5280

--- a/refs/snapshots/tagging_simple_with_link.txt
+++ b/refs/snapshots/tagging_simple_with_link.txt
@@ -19,37 +19,19 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [4 0 R]
+  /K [6 0 R]
   /ParentTree <<
-    /Nums [0 6 0 R 1 3 0 R]
+    /Nums [0 4 0 R 1 3 0 R]
   >>
   /ParentTreeNextKey 2
 >>
 endobj
 
 3 0 obj
-[6 0 R]
+[4 0 R]
 endobj
 
 4 0 obj
-<<
-  /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [5 0 R]
->>
-endobj
-
-5 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 4 0 R
-  /K [6 0 R]
->>
-endobj
-
-6 0 obj
 <<
   /Type /StructElem
   /S /Link
@@ -60,6 +42,24 @@ endobj
     /Obj 13 0 R
   >> 0]
   /Pg 14 0 R
+>>
+endobj
+
+5 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 6 0 R
+  /K [4 0 R]
+>>
+endobj
+
+6 0 obj
+<<
+  /Type /StructElem
+  /S /Document
+  /P 2 0 R
+  /K [5 0 R]
 >>
 endobj
 
@@ -281,8 +281,8 @@ xref
 0000000081 00000 n
 0000000315 00000 n
 0000000339 00000 n
-0000000420 00000 n
-0000000494 00000 n
+0000000480 00000 n
+0000000554 00000 n
 0000000635 00000 n
 0000000797 00000 n
 0000001106 00000 n
@@ -297,7 +297,7 @@ trailer
 <<
   /Size 17
   /Root 16 0 R
-  /ID [(1nyfyZGRc3bqIBtjRB9RTQ==) (1nyfyZGRc3bqIBtjRB9RTQ==)]
+  /ID [(Aha8kMV3lplv/1PsZ7G/Yw==) (Aha8kMV3lplv/1PsZ7G/Yw==)]
 >>
 startxref
 5566

--- a/refs/snapshots/tagging_strong_and_em_pdf_17.txt
+++ b/refs/snapshots/tagging_strong_and_em_pdf_17.txt
@@ -25,7 +25,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [5 0 R]
+  /K [8 0 R]
   /ParentTree <<
     /Nums [0 4 0 R]
   >>
@@ -34,44 +34,44 @@ endobj
 endobj
 
 4 0 obj
-[8 0 R 7 0 R]
+[5 0 R 6 0 R]
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 3 0 R
-  /K [6 0 R]
+  /S /Strong
+  /P 7 0 R
+  /K [0]
+  /Pg 15 0 R
 >>
 endobj
 
 6 0 obj
 <<
   /Type /StructElem
-  /S /P
-  /P 5 0 R
-  /K [8 0 R 7 0 R]
+  /S /Em
+  /P 7 0 R
+  /K [1]
+  /Pg 15 0 R
 >>
 endobj
 
 7 0 obj
 <<
   /Type /StructElem
-  /S /Em
-  /P 6 0 R
-  /K [1]
-  /Pg 15 0 R
+  /S /P
+  /P 8 0 R
+  /K [5 0 R 6 0 R]
 >>
 endobj
 
 8 0 obj
 <<
   /Type /StructElem
-  /S /Strong
-  /P 6 0 R
-  /K [0]
-  /Pg 15 0 R
+  /S /Document
+  /P 3 0 R
+  /K [7 0 R]
 >>
 endobj
 
@@ -324,7 +324,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Strong and Em</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>lByOVkdyAGL3CkYk+VxNVA==</xmpMM:InstanceID><xmpMM:DocumentID>lByOVkdyAGL3CkYk+VxNVA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Strong and Em</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>ZksfzlcfFbENGY2tz/NsgA==</xmpMM:InstanceID><xmpMM:DocumentID>ZksfzlcfFbENGY2tz/NsgA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -354,9 +354,9 @@ xref
 0000000121 00000 n
 0000000347 00000 n
 0000000377 00000 n
-0000000458 00000 n
-0000000538 00000 n
-0000000622 00000 n
+0000000465 00000 n
+0000000549 00000 n
+0000000629 00000 n
 0000000710 00000 n
 0000000873 00000 n
 0000001317 00000 n
@@ -373,7 +373,7 @@ trailer
   /Size 20
   /Root 19 0 R
   /Info 17 0 R
-  /ID [(lByOVkdyAGL3CkYk+VxNVA==) (lByOVkdyAGL3CkYk+VxNVA==)]
+  /ID [(ZksfzlcfFbENGY2tz/NsgA==) (ZksfzlcfFbENGY2tz/NsgA==)]
 >>
 startxref
 9034

--- a/refs/snapshots/tagging_strong_and_em_pdf_20.txt
+++ b/refs/snapshots/tagging_strong_and_em_pdf_20.txt
@@ -13,7 +13,7 @@ endobj
 <<
   /Type /StructTreeRoot
   /Namespaces [3 0 R 4 0 R]
-  /K [6 0 R]
+  /K [9 0 R]
   /ParentTree <<
     /Nums [0 5 0 R]
   >>
@@ -40,47 +40,47 @@ endobj
 endobj
 
 5 0 obj
-[9 0 R 8 0 R]
+[6 0 R 7 0 R]
 endobj
 
 6 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [7 0 R]
+  /S /Strong
+  /NS 3 0 R
+  /P 8 0 R
+  /K [0]
+  /Pg 15 0 R
 >>
 endobj
 
 7 0 obj
 <<
   /Type /StructElem
-  /S /P
+  /S /Em
   /NS 3 0 R
-  /P 6 0 R
-  /K [9 0 R 8 0 R]
+  /P 8 0 R
+  /K [1]
+  /Pg 15 0 R
 >>
 endobj
 
 8 0 obj
 <<
   /Type /StructElem
-  /S /Em
+  /S /P
   /NS 3 0 R
-  /P 7 0 R
-  /K [1]
-  /Pg 15 0 R
+  /P 9 0 R
+  /K [6 0 R 7 0 R]
 >>
 endobj
 
 9 0 obj
 <<
   /Type /StructElem
-  /S /Strong
-  /NS 3 0 R
-  /P 7 0 R
-  /K [0]
-  /Pg 15 0 R
+  /S /Document
+  /P 2 0 R
+  /K [8 0 R]
 >>
 endobj
 
@@ -329,9 +329,9 @@ xref
 0000000311 00000 n
 0000000469 00000 n
 0000000499 00000 n
-0000000580 00000 n
-0000000672 00000 n
-0000000768 00000 n
+0000000599 00000 n
+0000000695 00000 n
+0000000787 00000 n
 0000000868 00000 n
 0000001032 00000 n
 0000001476 00000 n
@@ -345,7 +345,7 @@ trailer
 <<
   /Size 19
   /Root 18 0 R
-  /ID [(iiAfZoPldJMKIz0gvKdWXg==) (iiAfZoPldJMKIz0gvKdWXg==)]
+  /ID [(VDCU/Ur7c+QkQg+UBACHew==) (VDCU/Ur7c+QkQg+UBACHew==)]
 >>
 startxref
 7807

--- a/refs/snapshots/tagging_table_header_and_footer.txt
+++ b/refs/snapshots/tagging_table_header_and_footer.txt
@@ -19,49 +19,63 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [4 0 R]
+  /K [27 0 R]
   /ParentTree <<
     /Nums [0 3 0 R]
   >>
   /IDTree <<
-    /Names [(UHeader 0) 27 0 R (UHeader 1) 26 0 R (UHeader 2) 25 0 R]
+    /Names [(UHeader 0) 4 0 R (UHeader 1) 5 0 R (UHeader 2) 6 0 R]
   >>
   /ParentTreeNextKey 1
 >>
 endobj
 
 3 0 obj
-[27 0 R 26 0 R 25 0 R 22 0 R 21 0 R 20 0 R 18 0 R 17 0 R 16 0 R 14 0 R 13 0 R 12 0 R 9 0 R]
+[4 0 R 5 0 R 6 0 R 9 0 R 10 0 R 11 0 R 13 0 R 14 0 R 15 0 R 17 0 R 18 0 R 19 0 R 22 0 R]
 endobj
 
 4 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [5 0 R]
+  /S /TH
+  /P 7 0 R
+  /ID (UHeader 0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+  >>]
+  /K [0]
+  /Pg 34 0 R
 >>
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Table
-  /P 4 0 R
+  /S /TH
+  /P 7 0 R
+  /ID (UHeader 1)
   /A [<<
     /O /Table
-    /Summary (table summary)
+    /Scope /Column
   >>]
-  /K [23 0 R 10 0 R 6 0 R]
+  /K [1]
+  /Pg 34 0 R
 >>
 endobj
 
 6 0 obj
 <<
   /Type /StructElem
-  /S /TFoot
-  /P 5 0 R
-  /K [8 0 R 7 0 R]
+  /S /TH
+  /P 7 0 R
+  /ID (UHeader 2)
+  /A [<<
+    /O /Table
+    /Scope /Column
+  >>]
+  /K [2]
+  /Pg 34 0 R
 >>
 endobj
 
@@ -69,17 +83,17 @@ endobj
 <<
   /Type /StructElem
   /S /TR
-  /P 6 0 R
-  /K []
+  /P 8 0 R
+  /K [4 0 R 5 0 R 6 0 R]
 >>
 endobj
 
 8 0 obj
 <<
   /Type /StructElem
-  /S /TR
-  /P 6 0 R
-  /K [9 0 R]
+  /S /THead
+  /P 26 0 R
+  /K [7 0 R]
 >>
 endobj
 
@@ -87,7 +101,169 @@ endobj
 <<
   /Type /StructElem
   /S /TD
-  /P 8 0 R
+  /P 12 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 0)]
+  >>]
+  /K [3]
+  /Pg 34 0 R
+>>
+endobj
+
+10 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 12 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 1)]
+  >>]
+  /K [4]
+  /Pg 34 0 R
+>>
+endobj
+
+11 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 12 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 2)]
+  >>]
+  /K [5]
+  /Pg 34 0 R
+>>
+endobj
+
+12 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 21 0 R
+  /K [9 0 R 10 0 R 11 0 R]
+>>
+endobj
+
+13 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 16 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 0)]
+  >>]
+  /K [6]
+  /Pg 34 0 R
+>>
+endobj
+
+14 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 16 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 1)]
+  >>]
+  /K [7]
+  /Pg 34 0 R
+>>
+endobj
+
+15 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 16 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 2)]
+  >>]
+  /K [8]
+  /Pg 34 0 R
+>>
+endobj
+
+16 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 21 0 R
+  /K [13 0 R 14 0 R 15 0 R]
+>>
+endobj
+
+17 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 20 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 0)]
+  >>]
+  /K [9]
+  /Pg 34 0 R
+>>
+endobj
+
+18 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 20 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 1)]
+  >>]
+  /K [10]
+  /Pg 34 0 R
+>>
+endobj
+
+19 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 20 0 R
+  /A [<<
+    /O /Table
+    /Headers [(UHeader 2)]
+  >>]
+  /K [11]
+  /Pg 34 0 R
+>>
+endobj
+
+20 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 21 0 R
+  /K [17 0 R 18 0 R 19 0 R]
+>>
+endobj
+
+21 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 26 0 R
+  /K [12 0 R 16 0 R 20 0 R]
+>>
+endobj
+
+22 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 23 0 R
   /A [<<
     /O /Table
     /Headers [(UHeader 0) (UHeader 1) (UHeader 2)]
@@ -99,174 +275,12 @@ endobj
 >>
 endobj
 
-10 0 obj
-<<
-  /Type /StructElem
-  /S /TBody
-  /P 5 0 R
-  /K [19 0 R 15 0 R 11 0 R]
->>
-endobj
-
-11 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 10 0 R
-  /K [14 0 R 13 0 R 12 0 R]
->>
-endobj
-
-12 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 11 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 2)]
-  >>]
-  /K [11]
-  /Pg 34 0 R
->>
-endobj
-
-13 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 11 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 1)]
-  >>]
-  /K [10]
-  /Pg 34 0 R
->>
-endobj
-
-14 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 11 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 0)]
-  >>]
-  /K [9]
-  /Pg 34 0 R
->>
-endobj
-
-15 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 10 0 R
-  /K [18 0 R 17 0 R 16 0 R]
->>
-endobj
-
-16 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 15 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 2)]
-  >>]
-  /K [8]
-  /Pg 34 0 R
->>
-endobj
-
-17 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 15 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 1)]
-  >>]
-  /K [7]
-  /Pg 34 0 R
->>
-endobj
-
-18 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 15 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 0)]
-  >>]
-  /K [6]
-  /Pg 34 0 R
->>
-endobj
-
-19 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 10 0 R
-  /K [22 0 R 21 0 R 20 0 R]
->>
-endobj
-
-20 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 19 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 2)]
-  >>]
-  /K [5]
-  /Pg 34 0 R
->>
-endobj
-
-21 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 19 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 1)]
-  >>]
-  /K [4]
-  /Pg 34 0 R
->>
-endobj
-
-22 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 19 0 R
-  /A [<<
-    /O /Table
-    /Headers [(UHeader 0)]
-  >>]
-  /K [3]
-  /Pg 34 0 R
->>
-endobj
-
 23 0 obj
 <<
   /Type /StructElem
-  /S /THead
-  /P 5 0 R
-  /K [24 0 R]
+  /S /TR
+  /P 25 0 R
+  /K [22 0 R]
 >>
 endobj
 
@@ -274,53 +288,39 @@ endobj
 <<
   /Type /StructElem
   /S /TR
-  /P 23 0 R
-  /K [27 0 R 26 0 R 25 0 R]
+  /P 25 0 R
+  /K []
 >>
 endobj
 
 25 0 obj
 <<
   /Type /StructElem
-  /S /TH
-  /P 24 0 R
-  /ID (UHeader 2)
-  /A [<<
-    /O /Table
-    /Scope /Column
-  >>]
-  /K [2]
-  /Pg 34 0 R
+  /S /TFoot
+  /P 26 0 R
+  /K [23 0 R 24 0 R]
 >>
 endobj
 
 26 0 obj
 <<
   /Type /StructElem
-  /S /TH
-  /P 24 0 R
-  /ID (UHeader 1)
+  /S /Table
+  /P 27 0 R
   /A [<<
     /O /Table
-    /Scope /Column
+    /Summary (table summary)
   >>]
-  /K [1]
-  /Pg 34 0 R
+  /K [8 0 R 21 0 R 25 0 R]
 >>
 endobj
 
 27 0 obj
 <<
   /Type /StructElem
-  /S /TH
-  /P 24 0 R
-  /ID (UHeader 0)
-  /A [<<
-    /O /Table
-    /Scope /Column
-  >>]
-  /K [0]
-  /Pg 34 0 R
+  /S /Document
+  /P 2 0 R
+  /K [26 0 R]
 >>
 endobj
 
@@ -727,46 +727,46 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000081 00000 n
-0000000395 00000 n
-0000000503 00000 n
-0000000584 00000 n
-0000000734 00000 n
-0000000818 00000 n
-0000000888 00000 n
-0000000963 00000 n
-0000001158 00000 n
-0000001252 00000 n
-0000001344 00000 n
-0000001487 00000 n
+0000000393 00000 n
+0000000498 00000 n
+0000000648 00000 n
+0000000798 00000 n
+0000000948 00000 n
+0000001035 00000 n
+0000001114 00000 n
+0000001255 00000 n
+0000001397 00000 n
+0000001539 00000 n
 0000001630 00000 n
 0000001772 00000 n
-0000001864 00000 n
-0000002006 00000 n
+0000001914 00000 n
+0000002056 00000 n
 0000002148 00000 n
 0000002290 00000 n
-0000002382 00000 n
-0000002524 00000 n
-0000002666 00000 n
-0000002808 00000 n
-0000002888 00000 n
-0000002980 00000 n
-0000003132 00000 n
-0000003284 00000 n
-0000003436 00000 n
-0000003600 00000 n
-0000004005 00000 n
-0000004122 00000 n
-0000004367 00000 n
-0000005305 00000 n
-0000009524 00000 n
-0000009741 00000 n
-0000011889 00000 n
+0000002433 00000 n
+0000002576 00000 n
+0000002668 00000 n
+0000002763 00000 n
+0000002960 00000 n
+0000003038 00000 n
+0000003110 00000 n
+0000003198 00000 n
+0000003350 00000 n
+0000003433 00000 n
+0000003597 00000 n
+0000004002 00000 n
+0000004119 00000 n
+0000004364 00000 n
+0000005302 00000 n
+0000009521 00000 n
+0000009738 00000 n
+0000011886 00000 n
 trailer
 <<
   /Size 37
   /Root 36 0 R
-  /ID [(x/7KVZv8Ofnnzkgpav5FPg==) (x/7KVZv8Ofnnzkgpav5FPg==)]
+  /ID [(KCbzQd0DsqNCXokgpoiGtA==) (KCbzQd0DsqNCXokgpoiGtA==)]
 >>
 startxref
-12025
+12022
 %%EOF

--- a/refs/snapshots/tagging_tag_attributes.txt
+++ b/refs/snapshots/tagging_tag_attributes.txt
@@ -19,29 +19,29 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [3 0 R]
+  /K [4 0 R]
 >>
 endobj
 
 3 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [4 0 R]
+  /S /Figure
+  /P 4 0 R
+  /Lang (en)
+  /Alt (The NASA logo)
+  /E (National Aeronautics and Space Administration)
+  /ActualText (NASA)
+  /K []
 >>
 endobj
 
 4 0 obj
 <<
   /Type /StructElem
-  /S /Figure
-  /P 3 0 R
-  /Lang (en)
-  /Alt (The NASA logo)
-  /E (National Aeronautics and Space Administration)
-  /ActualText (NASA)
-  /K []
+  /S /Document
+  /P 2 0 R
+  /K [3 0 R]
 >>
 endobj
 
@@ -191,7 +191,7 @@ xref
 0000000016 00000 n
 0000000080 00000 n
 0000000241 00000 n
-0000000322 00000 n
+0000000425 00000 n
 0000000506 00000 n
 0000000665 00000 n
 0000003472 00000 n
@@ -199,7 +199,7 @@ trailer
 <<
   /Size 8
   /Root 7 0 R
-  /ID [(9ho3C3lPit4lnGHW6VRRkQ==) (9ho3C3lPit4lnGHW6VRRkQ==)]
+  /ID [(i6H0a35VOUAhPl0tSy3aoQ==) (i6H0a35VOUAhPl0tSy3aoQ==)]
 >>
 startxref
 3607

--- a/refs/snapshots/tagging_two_footnotes.txt
+++ b/refs/snapshots/tagging_two_footnotes.txt
@@ -19,27 +19,29 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [4 0 R]
+  /K [6 0 R]
   /ParentTree <<
     /Nums [0 3 0 R]
   >>
   /IDTree <<
-    /Names [(Note 1) 6 0 R (Note 2) 5 0 R]
+    /Names [(Note 1) 4 0 R (Note 2) 5 0 R]
   >>
   /ParentTreeNextKey 1
 >>
 endobj
 
 3 0 obj
-[6 0 R 5 0 R]
+[4 0 R 5 0 R]
 endobj
 
 4 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 2 0 R
-  /K [6 0 R 5 0 R]
+  /S /Note
+  /P 6 0 R
+  /ID (Note 1)
+  /K [0]
+  /Pg 7 0 R
 >>
 endobj
 
@@ -47,7 +49,7 @@ endobj
 <<
   /Type /StructElem
   /S /Note
-  /P 4 0 R
+  /P 6 0 R
   /ID (Note 2)
   /K [1]
   /Pg 7 0 R
@@ -57,11 +59,9 @@ endobj
 6 0 obj
 <<
   /Type /StructElem
-  /S /Note
-  /P 4 0 R
-  /ID (Note 1)
-  /K [0]
-  /Pg 7 0 R
+  /S /Document
+  /P 2 0 R
+  /K [4 0 R 5 0 R]
 >>
 endobj
 
@@ -133,8 +133,8 @@ xref
 0000000080 00000 n
 0000000367 00000 n
 0000000397 00000 n
-0000000484 00000 n
-0000000584 00000 n
+0000000497 00000 n
+0000000597 00000 n
 0000000684 00000 n
 0000000862 00000 n
 0000001115 00000 n
@@ -142,7 +142,7 @@ trailer
 <<
   /Size 10
   /Root 9 0 R
-  /ID [(1JlRVaSylqAL/Ur/34XRZw==) (1JlRVaSylqAL/Ur/34XRZw==)]
+  /ID [(Uew6GoD7V2X1ZQYjO1wHIQ==) (Uew6GoD7V2X1ZQYjO1wHIQ==)]
 >>
 startxref
 1250

--- a/refs/snapshots/validate_pdf_ua1_attributes.txt
+++ b/refs/snapshots/validate_pdf_ua1_attributes.txt
@@ -25,7 +25,7 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [5 0 R]
+  /K [9 0 R]
   /ParentTree <<
     /Nums [0 4 0 R]
   >>
@@ -34,37 +34,24 @@ endobj
 endobj
 
 4 0 obj
-[9 0 R 8 0 R]
+[5 0 R 6 0 R]
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 3 0 R
-  /K [9 0 R 6 0 R]
+  /S /L
+  /P 9 0 R
+  /A [<<
+    /O /List
+    /ListNumbering /Circle
+  >>]
+  /K [0]
+  /Pg 10 0 R
 >>
 endobj
 
 6 0 obj
-<<
-  /Type /StructElem
-  /S /Table
-  /P 5 0 R
-  /K [7 0 R]
->>
-endobj
-
-7 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 6 0 R
-  /K [8 0 R]
->>
-endobj
-
-8 0 obj
 <<
   /Type /StructElem
   /S /TH
@@ -78,17 +65,30 @@ endobj
 >>
 endobj
 
+7 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 8 0 R
+  /K [6 0 R]
+>>
+endobj
+
+8 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 9 0 R
+  /K [7 0 R]
+>>
+endobj
+
 9 0 obj
 <<
   /Type /StructElem
-  /S /L
-  /P 5 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [0]
-  /Pg 10 0 R
+  /S /Document
+  /P 3 0 R
+  /K [5 0 R 8 0 R]
 >>
 endobj
 
@@ -154,7 +154,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">a nice title</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>ohv3gN2S9EwC2W45P1kQtw==</xmpMM:InstanceID><xmpMM:DocumentID>ohv3gN2S9EwC2W45P1kQtw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">a nice title</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>w/gIcobJiJc+vtpetPxOqQ==</xmpMM:InstanceID><xmpMM:DocumentID>w/gIcobJiJc+vtpetPxOqQ==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -184,10 +184,10 @@ xref
 0000000121 00000 n
 0000000347 00000 n
 0000000377 00000 n
-0000000464 00000 n
-0000000542 00000 n
-0000000617 00000 n
-0000000746 00000 n
+0000000515 00000 n
+0000000644 00000 n
+0000000719 00000 n
+0000000797 00000 n
 0000000884 00000 n
 0000001064 00000 n
 0000001309 00000 n
@@ -198,7 +198,7 @@ trailer
   /Size 15
   /Root 14 0 R
   /Info 12 0 R
-  /ID [(ohv3gN2S9EwC2W45P1kQtw==) (ohv3gN2S9EwC2W45P1kQtw==)]
+  /ID [(w/gIcobJiJc+vtpetPxOqQ==) (w/gIcobJiJc+vtpetPxOqQ==)]
 >>
 startxref
 2647

--- a/refs/snapshots/validate_pdf_ua1_full_example.txt
+++ b/refs/snapshots/validate_pdf_ua1_full_example.txt
@@ -25,38 +25,38 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [5 0 R]
+  /K [6 0 R]
   /ParentTree <<
-    /Nums [0 6 0 R 1 4 0 R]
+    /Nums [0 5 0 R 1 4 0 R]
   >>
   /ParentTreeNextKey 2
 >>
 endobj
 
 4 0 obj
-[5 0 R]
+[6 0 R]
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 3 0 R
-  /K [0 6 0 R]
-  /Pg 14 0 R
+  /S /Link
+  /P 6 0 R
+  /K [<<
+    /Type /OBJR
+    /Pg 14 0 R
+    /Obj 13 0 R
+  >>]
 >>
 endobj
 
 6 0 obj
 <<
   /Type /StructElem
-  /S /Link
-  /P 5 0 R
-  /K [<<
-    /Type /OBJR
-    /Pg 14 0 R
-    /Obj 13 0 R
-  >>]
+  /S /Document
+  /P 3 0 R
+  /K [0 5 0 R]
+  /Pg 14 0 R
 >>
 endobj
 
@@ -283,7 +283,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">a nice title</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>Sme0U3ZtQJe2DkixXvLesA==</xmpMM:InstanceID><xmpMM:DocumentID>Sme0U3ZtQJe2DkixXvLesA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">a nice title</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>j4OMbXt82z7pWzyxwi3G/Q==</xmpMM:InstanceID><xmpMM:DocumentID>j4OMbXt82z7pWzyxwi3G/Q==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -313,7 +313,7 @@ xref
 0000000121 00000 n
 0000000355 00000 n
 0000000379 00000 n
-0000000475 00000 n
+0000000505 00000 n
 0000000601 00000 n
 0000000763 00000 n
 0000001106 00000 n
@@ -331,7 +331,7 @@ trailer
   /Size 19
   /Root 18 0 R
   /Info 16 0 R
-  /ID [(Sme0U3ZtQJe2DkixXvLesA==) (Sme0U3ZtQJe2DkixXvLesA==)]
+  /ID [(j4OMbXt82z7pWzyxwi3G/Q==) (j4OMbXt82z7pWzyxwi3G/Q==)]
 >>
 startxref
 7296

--- a/refs/snapshots/validate_pdf_ua1_only_annotation.txt
+++ b/refs/snapshots/validate_pdf_ua1_only_annotation.txt
@@ -25,9 +25,9 @@ endobj
     /Strong /Span
     /Em /Span
   >>
-  /K [4 0 R]
+  /K [5 0 R]
   /ParentTree <<
-    /Nums [0 5 0 R]
+    /Nums [0 4 0 R]
   >>
   /ParentTreeNextKey 1
 >>
@@ -36,22 +36,22 @@ endobj
 4 0 obj
 <<
   /Type /StructElem
-  /S /Document
-  /P 3 0 R
-  /K [5 0 R]
+  /S /Link
+  /P 5 0 R
+  /K [<<
+    /Type /OBJR
+    /Pg 7 0 R
+    /Obj 6 0 R
+  >>]
 >>
 endobj
 
 5 0 obj
 <<
   /Type /StructElem
-  /S /Link
-  /P 4 0 R
-  /K [<<
-    /Type /OBJR
-    /Pg 7 0 R
-    /Obj 6 0 R
-  >>]
+  /S /Document
+  /P 3 0 R
+  /K [4 0 R]
 >>
 endobj
 
@@ -108,7 +108,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">a nice title</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>OnB2sQWQF+DwwgblE+Zvgw==</xmpMM:InstanceID><xmpMM:DocumentID>OnB2sQWQF+DwwgblE+Zvgw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">a nice title</rdf:li></rdf:Alt></dc:title><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><pdfuaid:part>1</pdfuaid:part><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>jQ3kkYSJrpf9vvm2rhreSA==</xmpMM:InstanceID><xmpMM:DocumentID>jQ3kkYSJrpf9vvm2rhreSA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -137,7 +137,7 @@ xref
 0000000080 00000 n
 0000000120 00000 n
 0000000346 00000 n
-0000000427 00000 n
+0000000470 00000 n
 0000000551 00000 n
 0000000783 00000 n
 0000000971 00000 n
@@ -149,7 +149,7 @@ trailer
   /Size 12
   /Root 11 0 R
   /Info 9 0 R
-  /ID [(OnB2sQWQF+DwwgblE+Zvgw==) (OnB2sQWQF+DwwgblE+Zvgw==)]
+  /ID [(jQ3kkYSJrpf9vvm2rhreSA==) (jQ3kkYSJrpf9vvm2rhreSA==)]
 >>
 startxref
 2360


### PR DESCRIPTION
Instead of creating a new chunk for each tag group, we just use one chunk for all tag groups. This does have the disadvantage of us losing control about which order the elements are serialized, but this seems less important than reducing memory usage. 😄 

This gets us from

```
     cells   pages      build      finish    peak before       peak       pdf    ratio
---------- ------- ---------- ----------- -------------- ---------- --------- --------
     10000      50      0.01s       0.02s             3M         8M      1.5M     5.0x
    100000     500      0.03s       0.11s            26M        73M     15.6M     4.7x
    500000    2500      0.09s       0.58s           125M       417M     79.5M     5.2x
   1000000    5000      0.18s       1.13s           417M       836M    161.1M     5.2x
```

to
```
     cells   pages      build      finish    peak before       peak       pdf    ratio
---------- ------- ---------- ----------- -------------- ---------- --------- --------
     10000      50      0.01s       0.02s             3M         6M      1.5M     4.1x
    100000     500      0.03s       0.09s            26M        56M     15.6M     3.6x
    500000    2500      0.09s       0.51s           125M       256M     79.7M     3.2x
   1000000    5000      0.18s       1.11s           256M       512M    161.7M     3.2x
```

Closes #353.