### PR TITLE
Make `serialize` methods write directly into chunk container

### DIFF
--- a/crates/krilla/src/chunk_container.rs
+++ b/crates/krilla/src/chunk_container.rs
@@ -12,8 +12,6 @@ use crate::util::{stable_hash_base64, Deferred};
 
 type DChunk = Deferred<Chunk>;
 
-pub(crate) type ChunkContainerFn = fn(&mut ChunkContainer) -> &mut Vec<DChunk>;
-
 /// Collects all chunks that we create while building
 /// the PDF and then writes them out in an orderly manner.
 #[derive(Default)]
@@ -27,22 +25,22 @@ pub(crate) struct ChunkContainer {
     pub(crate) struct_elements: Option<Chunk>,
     pub(crate) page_labels: Vec<Chunk>,
     pub(crate) annotations: Vec<Chunk>,
-    pub(crate) color_spaces: Vec<DChunk>,
+    pub(crate) color_spaces: Vec<Chunk>,
     pub(crate) destinations: Vec<Chunk>,
-    pub(crate) ext_g_states: Vec<DChunk>,
-    pub(crate) masks: Vec<DChunk>,
+    pub(crate) ext_g_states: Vec<Chunk>,
+    pub(crate) masks: Vec<Chunk>,
 
     // Mixed chunks.
     pub(crate) fonts: Vec<Chunk>,
-    pub(crate) shading_functions: Vec<DChunk>,
-    pub(crate) patterns: Vec<DChunk>,
+    pub(crate) shading_functions: Vec<Chunk>,
+    pub(crate) patterns: Vec<Chunk>,
     pub(crate) pages: Vec<DChunk>,
-    pub(crate) embedded_files: Vec<DChunk>,
+    pub(crate) embedded_files: Vec<Chunk>,
     pub(crate) embedded_pdfs: Vec<Deferred<KrillaResult<EmbeddedPdfChunk>>>,
 
     // Stream objects.
-    pub(crate) icc_profiles: Vec<DChunk>,
-    pub(crate) x_objects: Vec<DChunk>,
+    pub(crate) icc_profiles: Vec<Chunk>,
+    pub(crate) x_objects: Vec<Chunk>,
     pub(crate) images: Vec<Deferred<KrillaResult<Chunk>>>,
 
     pub(crate) metadata: Option<Metadata>,

--- a/crates/krilla/src/graphics/graphics_state.rs
+++ b/crates/krilla/src/graphics/graphics_state.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use pdf_writer::types::BlendMode;
 use pdf_writer::{Chunk, Finish, Name, Ref};
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::configure::ValidationError;
 use crate::geom::{Rect, Transform};
 use crate::graphics::mask::Mask;
@@ -12,7 +11,6 @@ use crate::num::NormalizedF32;
 use crate::resource;
 use crate::resource::Resourceable;
 use crate::serialize::{Cacheable, SerializeContext};
-use crate::util::Deferred;
 
 /// The inner representation of an external graphics state.
 #[derive(Debug, Hash, PartialEq, Eq, Default, Clone)]
@@ -106,11 +104,7 @@ impl ExtGState {
 }
 
 impl Cacheable for ExtGState {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.ext_g_states
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         let mut chunk = Chunk::new();
 
         let mut ext_st = chunk.ext_graphics(root_ref);
@@ -145,8 +139,7 @@ impl Cacheable for ExtGState {
         }
 
         ext_st.finish();
-
-        Deferred::new(|| chunk)
+        sc.chunk_container.ext_g_states.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/icc.rs
+++ b/crates/krilla/src/graphics/icc.rs
@@ -6,12 +6,11 @@ use std::sync::Arc;
 
 use pdf_writer::{Chunk, Finish, Name, Ref};
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::resource;
 use crate::resource::Resourceable;
 use crate::serialize::{Cacheable, SerializeContext};
 use crate::stream::{deflate_encode, FilterStreamBuilder};
-use crate::util::{Deferred, Prehashed};
+use crate::util::Prehashed;
 
 /// An ICC profile.
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
@@ -42,11 +41,7 @@ impl<const C: u8> ICCProfile<C> {
 }
 
 impl<const C: u8> Cacheable for ICCProfile<C> {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.icc_profiles
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         let mut chunk = Chunk::new();
         let icc_stream = FilterStreamBuilder::new_from_deflated(&self.0.deref().data)
             .finish(&sc.serialize_settings());
@@ -55,8 +50,7 @@ impl<const C: u8> Cacheable for ICCProfile<C> {
         icc_profile.n(C as i32).range([0.0, 1.0].repeat(C as usize));
         icc_stream.write_filters(icc_profile.deref_mut().deref_mut());
         icc_profile.finish();
-
-        Deferred::new(|| chunk)
+        sc.chunk_container.icc_profiles.push(chunk);
     }
 }
 
@@ -78,11 +72,7 @@ impl GenericICCProfile {
 }
 
 impl Cacheable for GenericICCProfile {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.icc_profiles
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         match self {
             GenericICCProfile::Luma(l) => l.serialize(sc, root_ref),
             GenericICCProfile::Rgb(r) => r.serialize(sc, root_ref),
@@ -95,11 +85,7 @@ impl Cacheable for GenericICCProfile {
 pub(crate) struct ICCBasedColorSpace<const C: u8>(pub(crate) ICCProfile<C>);
 
 impl<const C: u8> Cacheable for ICCBasedColorSpace<C> {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.color_spaces
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         let icc_ref = sc.register_cacheable(self.0.clone());
 
         let mut chunk = Chunk::new();
@@ -108,8 +94,7 @@ impl<const C: u8> Cacheable for ICCBasedColorSpace<C> {
         array.item(Name(b"ICCBased"));
         array.item(icc_ref);
         array.finish();
-
-        Deferred::new(|| chunk)
+        sc.chunk_container.color_spaces.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/mask.rs
+++ b/crates/krilla/src/graphics/mask.rs
@@ -2,7 +2,6 @@
 
 use pdf_writer::{Chunk, Finish, Name, Ref};
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::geom::{Rect, Transform};
 use crate::graphics::shading_function::{GradientProperties, ShadingFunction};
 use crate::graphics::xobject::XObject;
@@ -11,7 +10,6 @@ use crate::resource::Resourceable;
 use crate::serialize::{Cacheable, SerializeContext};
 use crate::stream::Stream;
 use crate::stream::StreamBuilder;
-use crate::util::Deferred;
 
 /// A mask. Can be a luminance mask or an alpha mask.
 ///
@@ -102,11 +100,7 @@ impl MaskType {
 }
 
 impl Cacheable for Mask {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.masks
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         let mut chunk = Chunk::new();
 
         let x_object =
@@ -118,8 +112,7 @@ impl Cacheable for Mask {
         dict.pair(Name(b"G"), x_object);
 
         dict.finish();
-
-        Deferred::new(|| chunk)
+        sc.chunk_container.masks.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/separation.rs
+++ b/crates/krilla/src/graphics/separation.rs
@@ -1,12 +1,10 @@
 use pdf_writer::writers::ExponentialFunction;
 use pdf_writer::{Chunk, Finish, Name, Ref, Writer};
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::color::separation::SeparationSpace;
 use crate::color::{DEVICE_CMYK, DEVICE_GRAY, DEVICE_RGB};
 use crate::resource::{self, Resource, Resourceable};
 use crate::serialize::{Cacheable, MaybeDeviceColorSpace, SerializeContext};
-use crate::util::Deferred;
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub(crate) struct SeparationColorSpace {
@@ -20,11 +18,7 @@ impl SeparationColorSpace {
 }
 
 impl Cacheable for SeparationColorSpace {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.color_spaces
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         // Delegate fallback color space registration to existing logic
         let fallback_cs = self.space.fallback.color_space(sc);
         let fallback_cs_resource = sc.register_colorspace(fallback_cs.into());
@@ -46,42 +40,40 @@ impl Cacheable for SeparationColorSpace {
             sc.register_validation_error(validation_error);
         }
 
-        Deferred::new(move || {
-            let mut chunk = Chunk::new();
+        let mut chunk = Chunk::new();
 
-            // Write Separation color space array: [/Separation name alternateSpace tintTransform]
-            let mut array = chunk.indirect(root_ref).array();
-            array.item(Name(b"Separation"));
+        // Write Separation color space array: [/Separation name alternateSpace tintTransform]
+        let mut array = chunk.indirect(root_ref).array();
+        array.item(Name(b"Separation"));
 
-            // Colorant name
-            array.item(self.space.colorant.to_pdf());
+        // Colorant name
+        array.item(self.space.colorant.to_pdf());
 
-            // Fallback color space - write as name for device CS, or ref for others
-            match fallback_cs_resource {
-                MaybeDeviceColorSpace::DeviceRgb => array.item(Name(DEVICE_RGB.as_bytes())),
-                MaybeDeviceColorSpace::DeviceGray => array.item(Name(DEVICE_GRAY.as_bytes())),
-                MaybeDeviceColorSpace::DeviceCMYK => array.item(Name(DEVICE_CMYK.as_bytes())),
-                MaybeDeviceColorSpace::ColorSpace(cs) => {
-                    // Use get_ref() to extract the underlying Ref
-                    array.item(cs.get_ref())
-                }
-            };
+        // Fallback color space - write as name for device CS, or ref for others
+        match fallback_cs_resource {
+            MaybeDeviceColorSpace::DeviceRgb => array.item(Name(DEVICE_RGB.as_bytes())),
+            MaybeDeviceColorSpace::DeviceGray => array.item(Name(DEVICE_GRAY.as_bytes())),
+            MaybeDeviceColorSpace::DeviceCMYK => array.item(Name(DEVICE_CMYK.as_bytes())),
+            MaybeDeviceColorSpace::ColorSpace(cs) => {
+                // Use get_ref() to extract the underlying Ref
+                array.item(cs.get_ref())
+            }
+        };
 
-            // Write Type 2 (Exponential) function for tint transform
-            // Maps tint [0.0-1.0] from white (no ink) to fallback color (full ink)
-            ExponentialFunction::start(array.push())
-                .domain([0.0, 1.0])
-                .range([0.0, 1.0].repeat(num_components))
-                // C0: white/no ink (tint = 0.0) - value depends on color space
-                .c0(vec![c0_value; num_components])
-                // C1: fallback color (tint = 1.0)
-                .c1(fallback_color)
-                .n(1.0);
+        // Write Type 2 (Exponential) function for tint transform
+        // Maps tint [0.0-1.0] from white (no ink) to fallback color (full ink)
+        ExponentialFunction::start(array.push())
+            .domain([0.0, 1.0])
+            .range([0.0, 1.0].repeat(num_components))
+            // C0: white/no ink (tint = 0.0) - value depends on color space
+            .c0(vec![c0_value; num_components])
+            // C1: fallback color (tint = 1.0)
+            .c1(fallback_color)
+            .n(1.0);
 
-            array.finish();
+        array.finish();
 
-            chunk
-        })
+        sc.chunk_container.color_spaces.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/shading_function.rs
+++ b/crates/krilla/src/graphics/shading_function.rs
@@ -7,7 +7,6 @@ use pdf_writer::types::{FunctionShadingType, PostScriptOp};
 use pdf_writer::{Chunk, Finish, Ref};
 use tiny_skia_path::Point;
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::configure::ValidationError;
 use crate::geom::{Rect, Transform};
 use crate::graphics::color::luma;
@@ -18,7 +17,7 @@ use crate::num::NormalizedF32;
 use crate::resource;
 use crate::resource::Resourceable;
 use crate::serialize::{Cacheable, SerializeContext};
-use crate::util::{set_colorspace, Deferred};
+use crate::util::set_colorspace;
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
 pub(crate) enum GradientType {
@@ -225,11 +224,7 @@ impl ShadingFunction {
 }
 
 impl Cacheable for ShadingFunction {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.shading_functions
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         let mut chunk = Chunk::new();
 
         match &self.0.properties {
@@ -242,7 +237,7 @@ impl Cacheable for ShadingFunction {
             }
         }
 
-        Deferred::new(|| chunk)
+        sc.chunk_container.shading_functions.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/shading_pattern.rs
+++ b/crates/krilla/src/graphics/shading_pattern.rs
@@ -3,13 +3,11 @@ use std::sync::Arc;
 
 use pdf_writer::{Chunk, Finish, Name, Ref};
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::geom::Transform;
 use crate::graphics::shading_function::{GradientProperties, ShadingFunction};
 use crate::resource;
 use crate::resource::Resourceable;
 use crate::serialize::{Cacheable, SerializeContext};
-use crate::util::Deferred;
 
 #[derive(Debug, PartialEq)]
 struct Repr {
@@ -40,11 +38,7 @@ impl ShadingPattern {
 }
 
 impl Cacheable for ShadingPattern {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.patterns
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         let mut chunk = Chunk::new();
 
         let shading_ref = sc.register_cacheable(self.0.shading_function.clone());
@@ -53,8 +47,7 @@ impl Cacheable for ShadingPattern {
         shading_pattern.matrix(self.0.shading_transform.to_pdf_transform());
 
         shading_pattern.finish();
-
-        Deferred::new(|| chunk)
+        sc.chunk_container.patterns.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/tiling_pattern.rs
+++ b/crates/krilla/src/graphics/tiling_pattern.rs
@@ -6,7 +6,6 @@ use std::ops::DerefMut;
 use pdf_writer::types::{PaintType, TilingType};
 use pdf_writer::{Chunk, Finish, Ref};
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::geom::Transform;
 use crate::num::NormalizedF32;
 use crate::resource;
@@ -14,7 +13,6 @@ use crate::resource::Resourceable;
 use crate::serialize::{Cacheable, SerializeContext};
 use crate::stream::StreamBuilder;
 use crate::stream::{FilterStreamBuilder, Stream};
-use crate::util::Deferred;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct TilingPattern {
@@ -73,11 +71,7 @@ impl TilingPattern {
 }
 
 impl Cacheable for TilingPattern {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.patterns
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         let mut chunk = Chunk::new();
 
         for validation_error in self.stream.validation_errors {
@@ -107,8 +101,7 @@ impl Cacheable for TilingPattern {
             .y_step(final_bbox.y2 - final_bbox.y1);
 
         tiling_pattern.finish();
-
-        Deferred::new(|| chunk)
+        sc.chunk_container.patterns.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/xobject.rs
+++ b/crates/krilla/src/graphics/xobject.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use pdf_writer::{Chunk, Finish, Name, Ref};
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::configure::ValidationError;
 use crate::geom::Rect;
 use crate::graphics::color::{rgb, DEVICE_RGB};
@@ -11,7 +10,7 @@ use crate::resource;
 use crate::resource::{Resource, Resourceable};
 use crate::serialize::{Cacheable, MaybeDeviceColorSpace, SerializeContext};
 use crate::stream::{FilterStreamBuilder, Stream};
-use crate::util::{Deferred, NameExt, Prehashed};
+use crate::util::{NameExt, Prehashed};
 
 #[derive(Debug, Hash, Eq, PartialEq)]
 struct Repr {
@@ -61,11 +60,7 @@ impl XObject {
 }
 
 impl Cacheable for XObject {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.x_objects
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         let mut chunk = Chunk::new();
 
         for validation_error in &self.0.stream.validation_errors {
@@ -93,55 +88,50 @@ impl Cacheable for XObject {
             None
         };
 
-        Deferred::new(move || {
-            let x_object_stream = FilterStreamBuilder::new_from_content_stream(
-                &self.0.stream.content,
-                &serialize_settings,
-            )
-            .finish(&serialize_settings);
-            let mut x_object = chunk.form_xobject(root_ref, x_object_stream.encoded_data());
-            x_object_stream.write_filters(x_object.deref_mut().deref_mut());
+        let x_object_stream = FilterStreamBuilder::new_from_content_stream(
+            &self.0.stream.content,
+            &serialize_settings,
+        )
+        .finish(&serialize_settings);
+        let mut x_object = chunk.form_xobject(root_ref, x_object_stream.encoded_data());
+        x_object_stream.write_filters(x_object.deref_mut().deref_mut());
 
+        self.0
+            .stream
+            .resource_dictionary
+            .to_pdf_resources(&mut x_object, serialize_settings.pdf_version());
+        x_object.bbox(
             self.0
-                .stream
-                .resource_dictionary
-                .to_pdf_resources(&mut x_object, serialize_settings.pdf_version());
-            x_object.bbox(
-                self.0
-                    .custom_bbox
-                    .unwrap_or(self.0.stream.bbox)
-                    .to_pdf_rect(),
-            );
+                .custom_bbox
+                .unwrap_or(self.0.stream.bbox)
+                .to_pdf_rect(),
+        );
 
-            if use_transparency_group {
-                let mut group = x_object.group();
-                let transparency = group.transparency();
+        if use_transparency_group {
+            let mut group = x_object.group();
+            let transparency = group.transparency();
 
-                if self.0.isolated {
-                    transparency.isolated(self.0.isolated);
-                }
-
-                if let Some(transparency_group_cs) = transparency_group_cs {
-                    let pdf_cs = transparency.insert(Name(b"CS"));
-
-                    match transparency_group_cs {
-                        MaybeDeviceColorSpace::DeviceRgb => {
-                            pdf_cs.primitive(DEVICE_RGB.to_pdf_name())
-                        }
-                        // Can only be SRGB
-                        MaybeDeviceColorSpace::ColorSpace(cs) => pdf_cs.primitive(cs.get_ref()),
-                        _ => unreachable!(),
-                    }
-                }
-
-                transparency.finish();
-                group.finish();
+            if self.0.isolated {
+                transparency.isolated(self.0.isolated);
             }
 
-            x_object.finish();
+            if let Some(transparency_group_cs) = transparency_group_cs {
+                let pdf_cs = transparency.insert(Name(b"CS"));
 
-            chunk
-        })
+                match transparency_group_cs {
+                    MaybeDeviceColorSpace::DeviceRgb => pdf_cs.primitive(DEVICE_RGB.to_pdf_name()),
+                    // Can only be SRGB
+                    MaybeDeviceColorSpace::ColorSpace(cs) => pdf_cs.primitive(cs.get_ref()),
+                    _ => unreachable!(),
+                }
+            }
+
+            transparency.finish();
+            group.finish();
+        }
+
+        x_object.finish();
+        sc.chunk_container.x_objects.push(chunk);
     }
 }
 

--- a/crates/krilla/src/interchange/embed.rs
+++ b/crates/krilla/src/interchange/embed.rs
@@ -4,14 +4,13 @@ use std::ops::DerefMut;
 
 use pdf_writer::{Chunk, Finish, Name, Ref, Str, TextStr};
 
-use crate::chunk_container::ChunkContainerFn;
 use crate::configure::{PdfVersion, ValidationError};
 use crate::interchange::metadata::pdf_date;
 use crate::metadata::DateTime;
 use crate::serialize::{Cacheable, SerializeContext};
 use crate::stream::FilterStreamBuilder;
 use crate::surface::Location;
-use crate::util::{Deferred, NameExt};
+use crate::util::NameExt;
 use crate::Data;
 
 /// An error while embedding the file.
@@ -52,11 +51,7 @@ pub struct EmbeddedFile {
 }
 
 impl Cacheable for EmbeddedFile {
-    fn chunk_container(&self) -> ChunkContainerFn {
-        |cc| &mut cc.embedded_files
-    }
-
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk> {
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
         sc.register_validation_error(ValidationError::EmbeddedFile(
             EmbedError::Existence,
             self.location,
@@ -134,8 +129,7 @@ impl Cacheable for EmbeddedFile {
         }
 
         file_spec.finish();
-
-        Deferred::new(|| chunk)
+        sc.chunk_container.embedded_files.push(chunk);
     }
 }
 

--- a/crates/krilla/src/page.rs
+++ b/crates/krilla/src/page.rs
@@ -367,11 +367,7 @@ impl InternalPage {
         }
     }
 
-    pub(crate) fn serialize(
-        self,
-        sc: &mut SerializeContext,
-        root_ref: Ref,
-    ) -> KrillaResult<Deferred<Chunk>> {
+    pub(crate) fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> KrillaResult<()> {
         let mut chunk = Chunk::new();
 
         let mut annotation_refs = vec![];
@@ -453,10 +449,12 @@ impl InternalPage {
 
         page.finish();
 
-        Ok(Deferred::new(move || {
+        sc.chunk_container.pages.push(Deferred::new(move || {
             chunk.extend(self.stream_chunk.wait());
             chunk
-        }))
+        }));
+
+        Ok(())
     }
 }
 

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -10,7 +10,7 @@ use pdf_writer::types::{StructRole, StructRole2};
 use pdf_writer::writers::{OutputIntent, StructTreeRoot};
 use pdf_writer::{Chunk, Finish, Limits, Name, Pdf, Ref, Str, TextStr};
 
-use crate::chunk_container::{ChunkContainer, ChunkContainerFn};
+use crate::chunk_container::ChunkContainer;
 use crate::color::{CieBasedColorSpace, DeviceColorSpace, SpecialColorSpace};
 use crate::configure::validate::ValidationStore;
 use crate::configure::{Configuration, PdfVersion, ValidationError, Validator};
@@ -34,7 +34,7 @@ use crate::resource::{Resource, Resourceable};
 use crate::surface::{Location, Surface};
 use crate::text::GlyphId;
 use crate::text::{Font, FontContainer, FontIdentifier};
-use crate::util::{Deferred, SipHashable};
+use crate::util::SipHashable;
 
 const STR_LEN: usize = 32767;
 const NAME_LEN: usize = 127;
@@ -549,9 +549,7 @@ impl SerializeContext {
         T: Cacheable,
     {
         self.register_cached(object, |sc, object, root_ref| {
-            let chunk_container_fn = object.chunk_container();
-            let chunk = object.serialize(sc, root_ref);
-            chunk_container_fn(&mut sc.chunk_container).push(chunk);
+            object.serialize(sc, root_ref);
         })
     }
 
@@ -717,8 +715,7 @@ impl SerializeContext {
     fn serialize_pages(&mut self) -> KrillaResult<()> {
         let pages = self.global_objects.pages.take();
         for (ref_, page) in pages {
-            let chunk = page.serialize(self, ref_)?;
-            self.chunk_container.pages.push(chunk);
+            page.serialize(self, ref_)?;
         }
 
         Ok(())
@@ -1028,6 +1025,5 @@ impl GlobalObjects {
 }
 
 pub(crate) trait Cacheable: SipHashable {
-    fn chunk_container(&self) -> ChunkContainerFn;
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) -> Deferred<Chunk>;
+    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref);
 }


### PR DESCRIPTION
So that we are not just limited to a single `Chunk` per object. Instead, objects that write multiple PDF objects can write them into different fields. This will allow us to split up most mixed fields into stream and non-stream fields.