### PR TITLE
Use a single chunk for outlines

### DIFF
--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -206,13 +206,12 @@ impl OutlineNode {
         // do not go into nodes that whose count is negative (i.e. nodes that are
         // closed). Therefore, in case the node is closed, the visible count is
         // just the node itself, so 1.
-        let visible_count = if self.open {
+
+        if self.open {
             1 + children.map_or(0, |children| children.visible_count)
         } else {
             1
-        };
-
-        visible_count
+        }
     }
 }
 

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -21,7 +21,6 @@
 use pdf_writer::writers::OutlineItem;
 use pdf_writer::{Chunk, Finish, Name, Ref, TextStr};
 
-use crate::error::KrillaResult;
 use crate::interactive::destination::XyzDestination;
 use crate::serialize::SerializeContext;
 
@@ -79,6 +78,25 @@ impl Outlineable for OutlineItem<'_> {
     }
 }
 
+struct SerializedChildren {
+    first: Ref,
+    last: Ref,
+    visible_count: usize,
+}
+
+impl SerializedChildren {
+    fn write(&self, outlineable: &mut impl Outlineable, negate_count: bool) {
+        outlineable.first(self.first);
+        outlineable.last(self.last);
+
+        let mut count = i32::try_from(self.visible_count).unwrap();
+        if negate_count {
+            count = -count;
+        }
+        outlineable.count(count);
+    }
+}
+
 impl Outline {
     /// Create a new, empty outline.
     pub fn new() -> Self {
@@ -90,27 +108,17 @@ impl Outline {
         self.children.push(node)
     }
 
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root: Ref) -> KrillaResult<()> {
+    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root: Ref) {
         let mut chunk = Chunk::new();
-        let mut sub_chunks = vec![];
+        let children = serialize_children(&self.children, root, &mut chunk, sc);
 
         let mut outline = chunk.outline(root);
-        serialize_children(
-            &self.children,
-            root,
-            &mut sub_chunks,
-            sc,
-            &mut outline,
-            false,
-        )?;
+        if let Some(children) = &children {
+            children.write(&mut outline, false);
+        }
         outline.finish();
 
-        for sub_chunk in sub_chunks {
-            chunk.extend(&sub_chunk);
-        }
-
         sc.chunk_container.outline = Some((root, chunk));
-        Ok(())
     }
 }
 
@@ -169,11 +177,9 @@ impl OutlineNode {
         root: Ref,
         next: Option<Ref>,
         prev: Option<Ref>,
-    ) -> KrillaResult<(Chunk, usize)> {
-        let mut chunk = Chunk::new();
-
-        let mut sub_chunks = vec![];
-
+        chunk: &mut Chunk,
+    ) -> usize {
+        let children = serialize_children(&self.children, root, chunk, sc);
         let mut outline_entry = chunk.outline_item(root);
         outline_entry.parent(parent);
 
@@ -185,14 +191,9 @@ impl OutlineNode {
             outline_entry.prev(prev);
         }
 
-        let visible_child_count = serialize_children(
-            &self.children,
-            root,
-            &mut sub_chunks,
-            sc,
-            &mut outline_entry,
-            !self.open,
-        )?;
+        if let Some(children) = &children {
+            children.write(&mut outline_entry, !self.open);
+        }
 
         outline_entry.title(TextStr(&self.text));
 
@@ -201,32 +202,26 @@ impl OutlineNode {
 
         outline_entry.finish();
 
-        for sub_chunk in sub_chunks {
-            chunk.extend(&sub_chunk);
-        }
-
         // See the algorithm described in the PDF spec. When recursing down, we
         // do not go into nodes that whose count is negative (i.e. nodes that are
         // closed). Therefore, in case the node is closed, the visible count is
         // just the node itself, so 1.
         let visible_count = if self.open {
-            1 + visible_child_count
+            1 + children.map_or(0, |children| children.visible_count)
         } else {
             1
         };
 
-        Ok((chunk, visible_count))
+        visible_count
     }
 }
 
 fn serialize_children(
     children: &[OutlineNode],
-    root: Ref,
-    sub_chunks: &mut Vec<Chunk>,
+    parent: Ref,
+    chunk: &mut Chunk,
     sc: &mut SerializeContext,
-    outlineable: &mut impl Outlineable,
-    negate_count: bool,
-) -> KrillaResult<usize> {
+) -> Option<SerializedChildren> {
     let mut visible_count = 0;
 
     if !children.is_empty() {
@@ -245,23 +240,19 @@ fn serialize_children(
 
             last = cur.unwrap();
 
-            let (chunk, child_visible_count) = children[i].serialize(sc, root, last, next, prev)?;
+            let child_visible_count = children[i].serialize(sc, parent, last, next, prev, chunk);
             visible_count += child_visible_count;
-            sub_chunks.push(chunk);
 
             prev = cur;
             cur = next;
         }
 
-        outlineable.first(first);
-        outlineable.last(last);
-
-        let mut count = i32::try_from(visible_count).unwrap();
-        if negate_count {
-            count = -count;
-        }
-        outlineable.count(count);
+        Some(SerializedChildren {
+            first,
+            last,
+            visible_count,
+        })
+    } else {
+        None
     }
-
-    Ok(visible_count)
 }

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -418,7 +418,7 @@ impl SerializeContext {
         // Serialize all objects that can only be written in the end.
         self.serialize_destination_profiles();
         self.serialize_page_label_tree();
-        self.serialize_outline()?;
+        self.serialize_outline();
         self.serialize_fonts()?;
         self.serialize_pages()?;
         self.serialize_page_tree();
@@ -666,16 +666,14 @@ impl SerializeContext {
         }
     }
 
-    fn serialize_outline(&mut self) -> KrillaResult<()> {
+    fn serialize_outline(&mut self) {
         let outline = self.global_objects.outline.take();
         if let Some(outline) = &outline {
             let outline_ref = self.new_ref();
-            outline.serialize(self, outline_ref)?;
+            outline.serialize(self, outline_ref);
         } else {
             self.register_validation_error(ValidationError::MissingDocumentOutline);
         }
-
-        Ok(())
     }
 
     #[cfg(feature = "pdf")]

--- a/refs/snapshots/outline_mixed_state.txt
+++ b/refs/snapshots/outline_mixed_state.txt
@@ -11,50 +11,49 @@ endobj
 
 2 0 obj
 <<
-  /Type /Outlines
-  /First 3 0 R
-  /Last 6 0 R
-  /Count 4
+  /Parent 3 0 R
+  /Title (Heading 1.1.1)
+  /Dest 8 0 R
 >>
 endobj
 
 3 0 obj
 <<
-  /Parent 2 0 R
-  /Next 6 0 R
-  /First 4 0 R
-  /Last 4 0 R
-  /Count 2
-  /Title (Heading 1)
-  /Dest 10 0 R
->>
-endobj
-
-4 0 obj
-<<
-  /Parent 3 0 R
-  /First 5 0 R
-  /Last 5 0 R
+  /Parent 4 0 R
+  /First 2 0 R
+  /Last 2 0 R
   /Count 1
   /Title (Heading 1.1)
   /Dest 9 0 R
 >>
 endobj
 
+4 0 obj
+<<
+  /Parent 7 0 R
+  /Next 6 0 R
+  /First 3 0 R
+  /Last 3 0 R
+  /Count 2
+  /Title (Heading 1)
+  /Dest 10 0 R
+>>
+endobj
+
 5 0 obj
 <<
-  /Parent 4 0 R
-  /Title (Heading 1.1.1)
-  /Dest 8 0 R
+  /Parent 6 0 R
+  /Title (Heading 2.1)
+  /Dest 11 0 R
 >>
 endobj
 
 6 0 obj
 <<
-  /Parent 2 0 R
-  /Prev 3 0 R
-  /First 7 0 R
-  /Last 7 0 R
+  /Parent 7 0 R
+  /Prev 4 0 R
+  /First 5 0 R
+  /Last 5 0 R
   /Count -1
   /Title (Heading 2)
   /Dest 12 0 R
@@ -63,9 +62,10 @@ endobj
 
 7 0 obj
 <<
-  /Parent 6 0 R
-  /Title (Heading 2.1)
-  /Dest 11 0 R
+  /Type /Outlines
+  /First 4 0 R
+  /Last 6 0 R
+  /Count 4
 >>
 endobj
 
@@ -156,7 +156,7 @@ endobj
 <<
   /Type /Catalog
   /Pages 1 0 R
-  /Outlines 2 0 R
+  /Outlines 7 0 R
 >>
 endobj
 
@@ -165,11 +165,11 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000095 00000 n
-0000000175 00000 n
-0000000303 00000 n
-0000000418 00000 n
-0000000495 00000 n
-0000000624 00000 n
+0000000172 00000 n
+0000000287 00000 n
+0000000415 00000 n
+0000000491 00000 n
+0000000620 00000 n
 0000000700 00000 n
 0000000739 00000 n
 0000000778 00000 n
@@ -186,7 +186,7 @@ trailer
 <<
   /Size 20
   /Root 19 0 R
-  /ID [(13Lex+8O1cIBK5pelR2r1Q==) (13Lex+8O1cIBK5pelR2r1Q==)]
+  /ID [(iaI3eWwl6WiGZ0RU74xZAQ==) (iaI3eWwl6WiGZ0RU74xZAQ==)]
 >>
 startxref
 1613

--- a/refs/snapshots/outline_open_state.txt
+++ b/refs/snapshots/outline_open_state.txt
@@ -11,19 +11,18 @@ endobj
 
 2 0 obj
 <<
-  /Type /Outlines
-  /First 3 0 R
-  /Last 5 0 R
-  /Count 3
+  /Parent 3 0 R
+  /Title (Heading 1.1)
+  /Dest 6 0 R
 >>
 endobj
 
 3 0 obj
 <<
-  /Parent 2 0 R
-  /Next 5 0 R
-  /First 4 0 R
-  /Last 4 0 R
+  /Parent 5 0 R
+  /Next 4 0 R
+  /First 2 0 R
+  /Last 2 0 R
   /Count 1
   /Title (Heading 1)
   /Dest 7 0 R
@@ -32,18 +31,19 @@ endobj
 
 4 0 obj
 <<
-  /Parent 3 0 R
-  /Title (Heading 1.1)
-  /Dest 6 0 R
+  /Parent 5 0 R
+  /Prev 3 0 R
+  /Title (Heading 2)
+  /Dest 8 0 R
 >>
 endobj
 
 5 0 obj
 <<
-  /Parent 2 0 R
-  /Prev 3 0 R
-  /Title (Heading 2)
-  /Dest 8 0 R
+  /Type /Outlines
+  /First 3 0 R
+  /Last 4 0 R
+  /Count 3
 >>
 endobj
 
@@ -126,7 +126,7 @@ endobj
 <<
   /Type /Catalog
   /Pages 1 0 R
-  /Outlines 2 0 R
+  /Outlines 5 0 R
 >>
 endobj
 
@@ -135,9 +135,9 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000094 00000 n
-0000000174 00000 n
-0000000301 00000 n
-0000000376 00000 n
+0000000169 00000 n
+0000000296 00000 n
+0000000383 00000 n
 0000000463 00000 n
 0000000502 00000 n
 0000000539 00000 n
@@ -152,7 +152,7 @@ trailer
 <<
   /Size 16
   /Root 15 0 R
-  /ID [(7nNb0MBCRVqNI7RGxH/VFQ==) (7nNb0MBCRVqNI7RGxH/VFQ==)]
+  /ID [(NVbxj1t5y0R2dGvEbXzgUw==) (NVbxj1t5y0R2dGvEbXzgUw==)]
 >>
 startxref
 1293

--- a/refs/snapshots/outline_simple.txt
+++ b/refs/snapshots/outline_simple.txt
@@ -11,19 +11,18 @@ endobj
 
 2 0 obj
 <<
-  /Type /Outlines
-  /First 3 0 R
-  /Last 5 0 R
-  /Count 2
+  /Parent 3 0 R
+  /Title (Heading 1.1)
+  /Dest 6 0 R
 >>
 endobj
 
 3 0 obj
 <<
-  /Parent 2 0 R
-  /Next 5 0 R
-  /First 4 0 R
-  /Last 4 0 R
+  /Parent 5 0 R
+  /Next 4 0 R
+  /First 2 0 R
+  /Last 2 0 R
   /Count -1
   /Title (Heading 1)
   /Dest 7 0 R
@@ -32,18 +31,19 @@ endobj
 
 4 0 obj
 <<
-  /Parent 3 0 R
-  /Title (Heading 1.1)
-  /Dest 6 0 R
+  /Parent 5 0 R
+  /Prev 3 0 R
+  /Title (Heading 2)
+  /Dest 8 0 R
 >>
 endobj
 
 5 0 obj
 <<
-  /Parent 2 0 R
-  /Prev 3 0 R
-  /Title (Heading 2)
-  /Dest 8 0 R
+  /Type /Outlines
+  /First 3 0 R
+  /Last 4 0 R
+  /Count 2
 >>
 endobj
 
@@ -153,7 +153,7 @@ endobj
 <<
   /Type /Catalog
   /Pages 1 0 R
-  /Outlines 2 0 R
+  /Outlines 5 0 R
 >>
 endobj
 
@@ -162,9 +162,9 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000094 00000 n
-0000000174 00000 n
-0000000302 00000 n
-0000000377 00000 n
+0000000169 00000 n
+0000000297 00000 n
+0000000384 00000 n
 0000000464 00000 n
 0000000503 00000 n
 0000000540 00000 n
@@ -179,7 +179,7 @@ trailer
 <<
   /Size 16
   /Root 15 0 R
-  /ID [(P4eqQuPHEhbtvdFVHS8VQQ==) (P4eqQuPHEhbtvdFVHS8VQQ==)]
+  /ID [(MaDhXFzyqOCOkDAe8Ho/3g==) (MaDhXFzyqOCOkDAe8Ho/3g==)]
 >>
 startxref
 1507

--- a/refs/snapshots/outline_with_empty_title.txt
+++ b/refs/snapshots/outline_with_empty_title.txt
@@ -11,18 +11,18 @@ endobj
 
 2 0 obj
 <<
-  /Type /Outlines
-  /First 3 0 R
-  /Last 3 0 R
-  /Count 1
+  /Parent 3 0 R
+  /Title ()
+  /Dest 4 0 R
 >>
 endobj
 
 3 0 obj
 <<
-  /Parent 2 0 R
-  /Title ()
-  /Dest 4 0 R
+  /Type /Outlines
+  /First 2 0 R
+  /Last 2 0 R
+  /Count 1
 >>
 endobj
 
@@ -55,7 +55,7 @@ endobj
 <<
   /Type /Catalog
   /Pages 1 0 R
-  /Outlines 2 0 R
+  /Outlines 3 0 R
 >>
 endobj
 
@@ -64,7 +64,7 @@ xref
 0000000000 65535 f
 0000000016 00000 n
 0000000080 00000 n
-0000000160 00000 n
+0000000144 00000 n
 0000000224 00000 n
 0000000261 00000 n
 0000000420 00000 n
@@ -73,7 +73,7 @@ trailer
 <<
   /Size 8
   /Root 7 0 R
-  /ID [(DiNK/bOKy2tY6sk9F9+7Vg==) (DiNK/bOKy2tY6sk9F9+7Vg==)]
+  /ID [(tNG/lAW8ZUvuM5CniYedZA==) (tNG/lAW8ZUvuM5CniYedZA==)]
 >>
 startxref
 544


### PR DESCRIPTION
Similarly to our change for tag groups, instead of wasting memory by creating a new chunk for each node, just create a single chunk for the whole outline.

This does once again change the order in which the outline nodes are serialized, but not like that really matters.