### PR TITLE
Use single chunk for each category

### DIFF
--- a/crates/krilla/src/chunk_container.rs
+++ b/crates/krilla/src/chunk_container.rs
@@ -14,7 +14,6 @@ type DChunk = Deferred<Chunk>;
 
 /// Collects all chunks that we create while building
 /// the PDF and then writes them out in an orderly manner.
-#[derive(Default)]
 pub(crate) struct ChunkContainer {
     // Non-stream objects.
     pub(crate) page_tree: Option<(Ref, Chunk)>,
@@ -23,17 +22,17 @@ pub(crate) struct ChunkContainer {
     pub(crate) destination_profiles: Option<(Ref, Chunk)>,
     pub(crate) struct_tree_root: Option<(Ref, Chunk)>,
     pub(crate) struct_elements: Option<Chunk>,
-    pub(crate) page_labels: Vec<Chunk>,
-    pub(crate) annotations: Vec<Chunk>,
-    pub(crate) color_spaces: Vec<Chunk>,
-    pub(crate) destinations: Vec<Chunk>,
-    pub(crate) ext_g_states: Vec<Chunk>,
-    pub(crate) masks: Vec<Chunk>,
-    pub(crate) fonts: Vec<Chunk>,
-    pub(crate) shading_functions: Vec<Chunk>,
-    pub(crate) patterns: Vec<Chunk>,
-    pub(crate) pages: Vec<Chunk>,
-    pub(crate) embedded_files: Vec<Chunk>,
+    pub(crate) page_labels: Chunk,
+    pub(crate) annotations: Chunk,
+    pub(crate) color_spaces: Chunk,
+    pub(crate) destinations: Chunk,
+    pub(crate) ext_g_states: Chunk,
+    pub(crate) masks: Chunk,
+    pub(crate) fonts: Chunk,
+    pub(crate) shading_functions: Chunk,
+    pub(crate) patterns: Chunk,
+    pub(crate) pages: Chunk,
+    pub(crate) embedded_files: Chunk,
 
     // Mixed chunks.
     pub(crate) embedded_pdfs: Vec<Deferred<KrillaResult<EmbeddedPdfChunk>>>,
@@ -53,7 +52,35 @@ pub(crate) struct ChunkContainer {
 
 impl ChunkContainer {
     pub(crate) fn new() -> Self {
-        Self::default()
+        Self {
+            page_tree: None,
+            outline: None,
+            page_label_tree: None,
+            destination_profiles: None,
+            struct_tree_root: None,
+            struct_elements: None,
+            page_labels: Chunk::new(),
+            annotations: Chunk::new(),
+            color_spaces: Chunk::new(),
+            destinations: Chunk::new(),
+            ext_g_states: Chunk::new(),
+            masks: Chunk::new(),
+            fonts: Chunk::new(),
+            shading_functions: Chunk::new(),
+            patterns: Chunk::new(),
+            pages: Chunk::new(),
+            embedded_files: Chunk::new(),
+            embedded_pdfs: vec![],
+            font_streams: vec![],
+            shading_function_streams: vec![],
+            pattern_streams: vec![],
+            page_streams: vec![],
+            embedded_file_streams: vec![],
+            icc_profiles: vec![],
+            x_objects: vec![],
+            images: vec![],
+            metadata: None,
+        }
     }
 
     pub(crate) fn finish(self, sc: &mut SerializeContext) -> KrillaResult<Pdf> {
@@ -137,7 +164,7 @@ impl ChunkContainer {
 
         sc.serialize_settings().validator().write_xmp(&mut xmp);
 
-        xmp.num_pages(self.pages.len() as u32);
+        xmp.num_pages(sc.page_infos().len() as u32);
         xmp.format("application/pdf");
         xmp.instance_id(&instance_id);
         xmp.document_id(&document_id);
@@ -246,7 +273,7 @@ impl ChunkContainer {
             let write_embedded_files = sc
                 .serialize_settings()
                 .validator()
-                .write_embedded_files(self.embedded_files.is_empty());
+                .write_embedded_files(self.embedded_files.len() == 0);
 
             if !named_destinations.is_empty() || write_embedded_files {
                 // Cannot use pdf-writer API here because it requires Ref's, while

--- a/crates/krilla/src/content.rs
+++ b/crates/krilla/src/content.rs
@@ -1024,6 +1024,7 @@ impl ContentBuilder {
         self.restore_graphics_state();
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn content_set_fill_stroke_properties(
         &mut self,
         bounds: Rect,

--- a/crates/krilla/src/content.rs
+++ b/crates/krilla/src/content.rs
@@ -10,6 +10,7 @@ use pdf_writer::types::TextRenderingMode;
 use pdf_writer::{Content, Finish, Name, Ref, Str, TextStr};
 use tiny_skia_path::{Path, PathSegment, PathVerb};
 
+use crate::chunk_container::ChunkContainer;
 use crate::color::rgb;
 use crate::configure::ValidationError;
 #[cfg(feature = "raster-images")]
@@ -190,6 +191,7 @@ impl ContentBuilder {
         mut fill: Option<&Fill>,
         stroke: Option<&Stroke>,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
     ) {
         if fill.is_none() && stroke.is_none() {
             return;
@@ -252,9 +254,17 @@ impl ContentBuilder {
             }
         };
 
-        let fill_op = |sb: &mut ContentBuilder, sc: &mut SerializeContext, fill: &Fill| {
+        let fill_op = |sb: &mut ContentBuilder,
+                       sc: &mut SerializeContext,
+                       chunk_container: &mut ChunkContainer,
+                       fill: &Fill| {
             let fill_rule = fill.rule;
-            sb.content_set_fill_properties(Rect::from_tsp(path.bounds()), fill, sc);
+            sb.content_set_fill_properties(
+                Rect::from_tsp(path.bounds()),
+                fill,
+                sc,
+                chunk_container,
+            );
             sb.content_draw_path(path.segments());
 
             match fill_rule {
@@ -265,21 +275,28 @@ impl ContentBuilder {
 
         let stroke_op = |sb: &mut ContentBuilder,
                          sc: &mut SerializeContext,
+                         chunk_container: &mut ChunkContainer,
                          stroke: &Stroke,
                          stroke_bbox: Rect| {
-            sb.content_set_stroke_properties(stroke_bbox, stroke, sc);
+            sb.content_set_stroke_properties(stroke_bbox, stroke, sc, chunk_container);
             sb.content_draw_path(path.segments());
             sb.content.stroke();
         };
 
         let fill_stroke_op = |sb: &mut ContentBuilder,
                               sc: &mut SerializeContext,
+                              chunk_container: &mut ChunkContainer,
                               fill: &Fill,
                               stroke: &Stroke,
                               stroke_bbox: Rect| {
             let fill_rule = fill.rule;
-            sb.content_set_fill_properties(Rect::from_tsp(path.bounds()), fill, sc);
-            sb.content_set_stroke_properties(stroke_bbox, stroke, sc);
+            sb.content_set_fill_properties(
+                Rect::from_tsp(path.bounds()),
+                fill,
+                sc,
+                chunk_container,
+            );
+            sb.content_set_stroke_properties(stroke_bbox, stroke, sc, chunk_container);
             sb.content_draw_path(path.segments());
 
             match fill_rule {
@@ -291,40 +308,43 @@ impl ContentBuilder {
         match (fill, stroke) {
             (Some(fill), None) => {
                 self.apply_isolated_op(
-                    |sb, _| {
+                    |sb, _, _| {
                         fill_prep(sb, fill);
                     },
-                    |sb, sc| {
-                        fill_op(sb, sc, fill);
+                    |sb, sc, chunk_container| {
+                        fill_op(sb, sc, chunk_container, fill);
                     },
                     sc,
+                    chunk_container,
                 );
             }
             (None, Some(stroke)) => {
                 let stroke_bbox = stroke_bbox(stroke);
 
                 self.apply_isolated_op(
-                    |sb, _| {
+                    |sb, _, _| {
                         stroke_prep(sb, stroke, stroke_bbox);
                     },
-                    |sb, sc| {
-                        stroke_op(sb, sc, stroke, stroke_bbox);
+                    |sb, sc, chunk_container| {
+                        stroke_op(sb, sc, chunk_container, stroke, stroke_bbox);
                     },
                     sc,
+                    chunk_container,
                 );
             }
             (Some(fill), Some(stroke)) => {
                 let stroke_bbox = stroke_bbox(stroke);
 
                 self.apply_isolated_op(
-                    |sb, _| {
+                    |sb, _, _| {
                         fill_prep(sb, fill);
                         stroke_prep(sb, stroke, stroke_bbox);
                     },
-                    |sb, sc| {
-                        fill_stroke_op(sb, sc, fill, stroke, stroke_bbox);
+                    |sb, sc, chunk_container| {
+                        fill_stroke_op(sb, sc, chunk_container, fill, stroke, stroke_bbox);
                     },
                     sc,
+                    chunk_container,
                 );
             }
             (None, None) => unreachable!(),
@@ -357,6 +377,7 @@ impl ContentBuilder {
         &mut self,
         start: Point,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
         fill: Option<&Fill>,
         stroke: Option<&Stroke>,
         context_color: rgb::Color,
@@ -377,7 +398,10 @@ impl ContentBuilder {
         let bbox_important = self.bbox_important;
         let calculate_bbox = |is_solid: bool| bbox_important || !is_solid;
 
-        let fill_action = |sb: &mut ContentBuilder, sc: &mut SerializeContext, fill: &Fill| {
+        let fill_action = |sb: &mut ContentBuilder,
+                           sc: &mut SerializeContext,
+                           chunk_container: &mut ChunkContainer,
+                           fill: &Fill| {
             let bbox = if calculate_bbox(matches!(&fill.paint.0, InnerPaint::Color(_))) {
                 let bbox = get_glyphs_bbox(glyphs, x, y, font_size, font.clone());
                 sb.expand_bbox(bbox);
@@ -386,22 +410,24 @@ impl ContentBuilder {
                 Rect::from_xywh(0.0, 0.0, 1.0, 1.0).unwrap()
             };
 
-            sb.content_set_fill_properties(bbox, fill, sc)
+            sb.content_set_fill_properties(bbox, fill, sc, chunk_container)
         };
 
-        let stroke_action =
-            |sb: &mut ContentBuilder, sc: &mut SerializeContext, stroke: &Stroke| {
-                let bbox = if calculate_bbox(matches!(&stroke.paint.0, InnerPaint::Color(_))) {
-                    // TODO: Bbox should also account for stroke.
-                    let bbox = get_glyphs_bbox(glyphs, x, y, font_size, font.clone());
-                    sb.expand_bbox(bbox);
-                    bbox
-                } else {
-                    Rect::from_xywh(0.0, 0.0, 1.0, 1.0).unwrap()
-                };
-
-                sb.content_set_stroke_properties(bbox, stroke, sc);
+        let stroke_action = |sb: &mut ContentBuilder,
+                             sc: &mut SerializeContext,
+                             chunk_container: &mut ChunkContainer,
+                             stroke: &Stroke| {
+            let bbox = if calculate_bbox(matches!(&stroke.paint.0, InnerPaint::Color(_))) {
+                // TODO: Bbox should also account for stroke.
+                let bbox = get_glyphs_bbox(glyphs, x, y, font_size, font.clone());
+                sb.expand_bbox(bbox);
+                bbox
+            } else {
+                Rect::from_xywh(0.0, 0.0, 1.0, 1.0).unwrap()
             };
+
+            sb.content_set_stroke_properties(bbox, stroke, sc, chunk_container);
+        };
 
         let set_fill_opacity = |sb: &mut ContentBuilder, fill: &Fill| {
             // PDF viewers don't show patterns with fill/stroke opacities consistently.
@@ -433,10 +459,11 @@ impl ContentBuilder {
                     x,
                     y,
                     sc,
+                    chunk_container,
                     TextRenderingMode::FillStroke,
-                    |sb, sc| {
-                        fill_action(sb, sc, f);
-                        stroke_action(sb, sc, s);
+                    |sb, sc, chunk_container| {
+                        fill_action(sb, sc, chunk_container, f);
+                        stroke_action(sb, sc, chunk_container, s);
                     },
                     glyphs,
                     font.clone(),
@@ -452,9 +479,10 @@ impl ContentBuilder {
                     x,
                     y,
                     sc,
+                    chunk_container,
                     TextRenderingMode::Fill,
-                    |sb, sc| {
-                        fill_action(sb, sc, f);
+                    |sb, sc, chunk_container| {
+                        fill_action(sb, sc, chunk_container, f);
                     },
                     glyphs,
                     font.clone(),
@@ -470,9 +498,10 @@ impl ContentBuilder {
                     x,
                     y,
                     sc,
+                    chunk_container,
                     TextRenderingMode::Stroke,
-                    |sb, sc| {
-                        stroke_action(sb, sc, s);
+                    |sb, sc, chunk_container| {
+                        stroke_action(sb, sc, chunk_container, s);
                     },
                     glyphs,
                     font.clone(),
@@ -629,8 +658,9 @@ impl ContentBuilder {
         x: f32,
         ys: f32,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
         fill_render_mode: TextRenderingMode,
-        action: impl FnOnce(&mut ContentBuilder, &mut SerializeContext),
+        action: impl FnOnce(&mut ContentBuilder, &mut SerializeContext, &mut ChunkContainer),
         glyphs: &[impl Glyph],
         font: Font,
         context_color: rgb::Color,
@@ -642,8 +672,8 @@ impl ContentBuilder {
         }
 
         self.apply_isolated_op(
-            |_, _| {},
-            |sb, sc| {
+            |_, _, _| {},
+            |sb, sc, chunk_container| {
                 let mut cur_x = x;
                 let mut cur_y = ys;
 
@@ -654,7 +684,7 @@ impl ContentBuilder {
                         .windows(2)
                         .all(|w| w[0].text_range().start >= w[1].text_range().end);
 
-                action(sb, sc);
+                action(sb, sc, chunk_container);
                 sb.content.begin_text();
 
                 let font_container = sc.register_font_container(font.clone());
@@ -714,6 +744,7 @@ impl ContentBuilder {
                 sb.content.end_text();
             },
             sc,
+            chunk_container,
         )
     }
 
@@ -816,22 +847,24 @@ impl ContentBuilder {
     pub(crate) fn draw_xobject(
         &mut self,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
         x_object: XObject,
         state: &ExtGState,
     ) {
         let bbox = x_object.bbox();
         self.apply_isolated_op(
-            |sb, _| {
+            |sb, _, _| {
                 sb.graphics_states.combine(state);
                 sb.expand_bbox(bbox);
             },
-            move |sb, sc| {
+            move |sb, sc, chunk_container| {
                 let x_object_name = sb
                     .rd_builder
-                    .register_resource(sc.register_resourceable(x_object));
+                    .register_resource(sc.register_resourceable(chunk_container, x_object));
                 sb.content.x_object(x_object_name.to_pdf_name());
             },
             sc,
+            chunk_container,
         );
     }
 
@@ -839,34 +872,43 @@ impl ContentBuilder {
     pub(crate) fn draw_xobject_by_reference(
         &mut self,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
         bbox: Rect,
         x_object: Ref,
     ) {
         // TODO: Consider bbox of XObject somehow?
         self.apply_isolated_op(
-            |sb, _| {
+            |sb, _, _| {
                 sb.expand_bbox(bbox);
             },
-            move |sb, _| {
+            move |sb, _, _| {
                 let x_object_name = sb
                     .rd_builder
                     .register_resource(resource::XObject::new(x_object));
                 sb.content.x_object(x_object_name.to_pdf_name());
             },
             sc,
+            chunk_container,
         );
     }
 
-    pub(crate) fn draw_masked(&mut self, sc: &mut SerializeContext, mask: Mask, stream: Stream) {
-        let state = ExtGState::new().mask(mask, sc);
+    pub(crate) fn draw_masked(
+        &mut self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        mask: Mask,
+        stream: Stream,
+    ) {
+        let state = ExtGState::new().mask(mask, sc, chunk_container);
         self.uses_mask = true;
         let x_object = XObject::new(stream, false, true, None);
-        self.draw_xobject(sc, x_object, &state);
+        self.draw_xobject(sc, chunk_container, x_object, &state);
     }
 
     pub(crate) fn draw_opacified(
         &mut self,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
         opacity: NormalizedF32,
         stream: Stream,
     ) {
@@ -874,46 +916,64 @@ impl ContentBuilder {
             .stroking_alpha(opacity)
             .non_stroking_alpha(opacity);
         let x_object = XObject::new(stream, true, false, None);
-        self.draw_xobject(sc, x_object, &state);
+        self.draw_xobject(sc, chunk_container, x_object, &state);
     }
 
-    pub(crate) fn draw_isolated(&mut self, sc: &mut SerializeContext, stream: Stream) {
+    pub(crate) fn draw_isolated(
+        &mut self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        stream: Stream,
+    ) {
         let state = ExtGState::new();
         let x_object = XObject::new(stream, true, false, None);
-        self.draw_xobject(sc, x_object, &state);
+        self.draw_xobject(sc, chunk_container, x_object, &state);
     }
 
     #[cfg(feature = "raster-images")]
-    pub(crate) fn draw_image(&mut self, image: Image, size: Size, sc: &mut SerializeContext) {
+    pub(crate) fn draw_image(
+        &mut self,
+        image: Image,
+        size: Size,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+    ) {
         self.apply_isolated_op(
-            |sb, _| {
+            |sb, _, _| {
                 // Scale the image from 1x1 to the actual dimensions.
                 let transform =
                     Transform::from_row(size.width(), 0.0, 0.0, -size.height(), 0.0, size.height());
                 sb.concat_transform(&transform);
                 sb.expand_bbox(Rect::from_xywh(0.0, 0.0, 1.0, 1.0).unwrap());
             },
-            move |sb, sc| {
-                let image_name = sb
-                    .rd_builder
-                    .register_resource(resource::XObject::new(sc.register_image(image)));
+            move |sb, sc, chunk_container| {
+                let image_name = sb.rd_builder.register_resource(resource::XObject::new(
+                    sc.register_image(chunk_container, image),
+                ));
 
                 sb.content.x_object(image_name.to_pdf_name());
             },
             sc,
+            chunk_container,
         );
     }
 
-    pub(crate) fn draw_shading(&mut self, shading: &ShadingFunction, sc: &mut SerializeContext) {
+    pub(crate) fn draw_shading(
+        &mut self,
+        shading: &ShadingFunction,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+    ) {
         self.apply_isolated_op(
-            |_, _| {},
-            move |sb, sc| {
+            |_, _, _| {},
+            move |sb, sc, chunk_container| {
                 let sh = sb
                     .rd_builder
-                    .register_resource(sc.register_resourceable(shading.clone()));
+                    .register_resource(sc.register_resourceable(chunk_container, shading.clone()));
                 sb.content.shading(sh.to_pdf_name());
             },
             sc,
+            chunk_container,
         )
     }
 
@@ -933,14 +993,15 @@ impl ContentBuilder {
 
     fn apply_isolated_op(
         &mut self,
-        prep: impl FnOnce(&mut Self, &mut SerializeContext),
-        op: impl FnOnce(&mut Self, &mut SerializeContext),
+        prep: impl FnOnce(&mut Self, &mut SerializeContext, &mut ChunkContainer),
+        op: impl FnOnce(&mut Self, &mut SerializeContext, &mut ChunkContainer),
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
     ) {
         self.save_graphics_state();
         self.content_save_state();
 
-        prep(self, sc);
+        prep(self, sc, chunk_container);
 
         let transform = self.cur_transform_with_root_transform();
 
@@ -951,13 +1012,13 @@ impl ContentBuilder {
         let state = self.graphics_states.cur().ext_g_state().clone();
 
         if !state.empty() {
-            let ext = self
-                .rd_builder
-                .register_resource::<resource::ExtGState>(sc.register_resourceable(state));
+            let ext = self.rd_builder.register_resource::<resource::ExtGState>(
+                sc.register_resourceable(chunk_container, state),
+            );
             self.content.set_parameters(ext.to_pdf_name());
         }
 
-        op(self, sc);
+        op(self, sc, chunk_container);
 
         self.content.restore_state();
         self.restore_graphics_state();
@@ -969,6 +1030,7 @@ impl ContentBuilder {
         paint: &Paint,
         opacity: NormalizedF32,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
         mut set_pattern_fn: impl FnMut(&mut Content, String),
         mut set_solid_fn: impl FnMut(&mut Content, ContentColorSpace, &Color),
     ) {
@@ -979,17 +1041,24 @@ impl ContentBuilder {
         let mut write_gradient =
             |gradient_props: GradientProperties,
              sc: &mut SerializeContext,
+             chunk_container: &mut ChunkContainer,
              transform: Transform,
              content_builder: &mut ContentBuilder| {
                 if let Some((color, opacity)) = gradient_props.single_stop_color() {
                     // Write gradients with one stop as a solid color fill.
                     content_builder.set_fill_opacity(opacity);
                     let cs = color.color_space(sc);
-                    let color_space_resource = Self::cs_to_content_cs(content_builder, sc, cs);
+                    let color_space_resource =
+                        Self::cs_to_content_cs(content_builder, sc, chunk_container, cs);
                     set_solid_fn(&mut content_builder.content, color_space_resource, color);
                 } else {
-                    let shading_mask =
-                        Mask::new_from_shading(gradient_props.clone(), transform, bounds, sc);
+                    let shading_mask = Mask::new_from_shading(
+                        gradient_props.clone(),
+                        transform,
+                        bounds,
+                        sc,
+                        chunk_container,
+                    );
 
                     let shading_pattern = ShadingPattern::new(
                         gradient_props,
@@ -1000,17 +1069,17 @@ impl ContentBuilder {
                     let color_space = content_builder
                         .rd_builder
                         .register_resource::<resource::Pattern>(
-                            sc.register_resourceable(shading_pattern),
+                            sc.register_resourceable(chunk_container, shading_pattern),
                         );
 
                     if let Some(shading_mask) = shading_mask {
-                        let state = ExtGState::new().mask(shading_mask, sc);
+                        let state = ExtGState::new().mask(shading_mask, sc, chunk_container);
                         content_builder.uses_mask = true;
 
                         let ext = content_builder
                             .rd_builder
                             .register_resource::<resource::ExtGState>(
-                                sc.register_resourceable(state),
+                                sc.register_resourceable(chunk_container, state),
                             );
                         content_builder.content.set_parameters(ext.to_pdf_name());
                     }
@@ -1022,20 +1091,20 @@ impl ContentBuilder {
         match &paint.0 {
             InnerPaint::Color(c) => {
                 let cs = c.color_space(sc);
-                let color_space_resource = Self::cs_to_content_cs(self, sc, cs);
+                let color_space_resource = Self::cs_to_content_cs(self, sc, chunk_container, cs);
                 set_solid_fn(&mut self.content, color_space_resource, c);
             }
             InnerPaint::LinearGradient(lg) => {
                 let (gradient_props, transform) = lg.clone().gradient_properties(bounds);
-                write_gradient(gradient_props, sc, transform, self);
+                write_gradient(gradient_props, sc, chunk_container, transform, self);
             }
             InnerPaint::RadialGradient(rg) => {
                 let (gradient_props, transform) = rg.clone().gradient_properties(bounds);
-                write_gradient(gradient_props, sc, transform, self);
+                write_gradient(gradient_props, sc, chunk_container, transform, self);
             }
             InnerPaint::SweepGradient(sg) => {
                 let (gradient_props, transform) = sg.clone().gradient_properties(bounds);
-                write_gradient(gradient_props, sc, transform, self);
+                write_gradient(gradient_props, sc, chunk_container, transform, self);
             }
             InnerPaint::Pattern(pat) => {
                 let mut pat = Arc::unwrap_or_clone(pat.clone());
@@ -1048,10 +1117,11 @@ impl ContentBuilder {
                     pat.width,
                     pat.height,
                     sc,
+                    chunk_container,
                 );
 
                 let color_space = self.rd_builder.register_resource::<resource::Pattern>(
-                    sc.register_resourceable(tiling_pattern),
+                    sc.register_resourceable(chunk_container, tiling_pattern),
                 );
                 set_pattern_fn(&mut self.content, color_space);
             }
@@ -1061,9 +1131,10 @@ impl ContentBuilder {
     fn cs_to_content_cs(
         content_builder: &mut ContentBuilder,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
         cs: ColorSpace,
     ) -> ContentColorSpace {
-        match sc.register_colorspace(cs) {
+        match sc.register_colorspace(chunk_container, cs) {
             MaybeDeviceColorSpace::ColorSpace(s) => {
                 ContentColorSpace::Named(content_builder.rd_builder.register_resource(s))
             }
@@ -1078,6 +1149,7 @@ impl ContentBuilder {
         bounds: Rect,
         fill: &Fill,
         serializer_context: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
     ) {
         fn set_pattern_fn(content: &mut Content, color_space: String) {
             content.set_fill_color_space(pdf_writer::types::ColorSpaceOperand::Pattern);
@@ -1114,6 +1186,7 @@ impl ContentBuilder {
             &fill.paint,
             fill.opacity,
             serializer_context,
+            chunk_container,
             set_pattern_fn,
             set_solid_fn,
         );
@@ -1124,6 +1197,7 @@ impl ContentBuilder {
         bounds: Rect,
         stroke: &Stroke,
         serializer_context: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
     ) {
         fn set_pattern_fn(content: &mut Content, color_space: String) {
             content.set_stroke_color_space(pdf_writer::types::ColorSpaceOperand::Pattern);
@@ -1160,6 +1234,7 @@ impl ContentBuilder {
             &stroke.paint,
             stroke.opacity,
             serializer_context,
+            chunk_container,
             set_pattern_fn,
             set_solid_fn,
         );

--- a/crates/krilla/src/document.rs
+++ b/crates/krilla/src/document.rs
@@ -14,6 +14,7 @@
 //!
 //! [`Page`]: Page
 
+use crate::chunk_container::ChunkContainer;
 use crate::destination::NamedDestination;
 use crate::error::KrillaResult;
 use crate::interchange::embed::EmbeddedFile;
@@ -29,6 +30,7 @@ use crate::surface::Location;
 /// A PDF document.
 pub struct Document {
     pub(crate) serializer_context: SerializeContext,
+    pub(crate) chunk_container: ChunkContainer,
 }
 
 impl Default for Document {
@@ -42,6 +44,7 @@ impl Document {
     pub fn new() -> Self {
         Self {
             serializer_context: SerializeContext::new(SerializeSettings::default()),
+            chunk_container: ChunkContainer::new(),
         }
     }
 
@@ -49,6 +52,7 @@ impl Document {
     pub fn new_with(serialize_settings: SerializeSettings) -> Self {
         Self {
             serializer_context: SerializeContext::new(serialize_settings),
+            chunk_container: ChunkContainer::new(),
         }
     }
 
@@ -57,6 +61,7 @@ impl Document {
         let page_index = self.serializer_context.page_infos().iter().len();
         Page::new(
             &mut self.serializer_context,
+            &mut self.chunk_container,
             page_index,
             PageSettings::default(),
         )
@@ -65,7 +70,12 @@ impl Document {
     /// Start a new page with specific page settings.
     pub fn start_page_with(&mut self, page_settings: PageSettings) -> Page<'_> {
         let page_index = self.serializer_context.page_infos().iter().len();
-        Page::new(&mut self.serializer_context, page_index, page_settings)
+        Page::new(
+            &mut self.serializer_context,
+            &mut self.chunk_container,
+            page_index,
+            page_settings,
+        )
     }
 
     /// Embed the pages (0-indexed) from the given
@@ -92,7 +102,7 @@ impl Document {
 
     /// Set the metadata of the document.
     pub fn set_metadata(&mut self, metadata: Metadata) {
-        self.serializer_context.set_metadata(metadata);
+        self.chunk_container.metadata = Some(metadata);
     }
 
     /// Set the tag tree of the document.
@@ -105,7 +115,8 @@ impl Document {
     /// Returns `None` if the file couldn't be embedded because a file
     /// with the same name has already been embedded.
     pub fn embed_file(&mut self, file: EmbeddedFile) -> Option<()> {
-        self.serializer_context.embed_file(file)
+        self.serializer_context
+            .embed_file(&mut self.chunk_container, file)
     }
 
     /// Manually register a global named destination.
@@ -123,6 +134,11 @@ impl Document {
             self.start_page();
         }
 
-        Ok(self.serializer_context.finish()?.finish())
+        let Self {
+            serializer_context,
+            chunk_container,
+        } = self;
+
+        Ok(serializer_context.finish(chunk_container)?.finish())
     }
 }

--- a/crates/krilla/src/graphics/graphics_state.rs
+++ b/crates/krilla/src/graphics/graphics_state.rs
@@ -2,8 +2,9 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use pdf_writer::types::BlendMode;
-use pdf_writer::{Chunk, Finish, Name, Ref};
+use pdf_writer::{Finish, Name, Ref};
 
+use crate::chunk_container::ChunkContainer;
 use crate::configure::ValidationError;
 use crate::geom::{Rect, Transform};
 use crate::graphics::mask::Mask;
@@ -67,8 +68,13 @@ impl ExtGState {
 
     /// Create a new graphics state with a mask.
     #[must_use]
-    pub(crate) fn mask(mut self, mask: Mask, sc: &mut SerializeContext) -> Self {
-        let mask_ref = sc.register_cacheable(mask);
+    pub(crate) fn mask(
+        mut self,
+        mask: Mask,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+    ) -> Self {
+        let mask_ref = sc.register_cacheable(chunk_container, mask);
         Arc::make_mut(&mut self.0).mask = Some(mask_ref);
         self
     }
@@ -104,8 +110,13 @@ impl ExtGState {
 }
 
 impl Cacheable for ExtGState {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
-        let mut chunk = Chunk::new();
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
+        let chunk = &mut chunk_container.ext_g_states;
 
         let mut ext_st = chunk.ext_graphics(root_ref);
         if let Some(nsa) = self.0.non_stroking_alpha {
@@ -139,7 +150,6 @@ impl Cacheable for ExtGState {
         }
 
         ext_st.finish();
-        sc.chunk_container.ext_g_states.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/icc.rs
+++ b/crates/krilla/src/graphics/icc.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use pdf_writer::{Chunk, Finish, Name, Ref};
 
+use crate::chunk_container::ChunkContainer;
 use crate::resource;
 use crate::resource::Resourceable;
 use crate::serialize::{Cacheable, SerializeContext};
@@ -41,7 +42,12 @@ impl<const C: u8> ICCProfile<C> {
 }
 
 impl<const C: u8> Cacheable for ICCProfile<C> {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         let mut chunk = Chunk::new();
         let icc_stream = FilterStreamBuilder::new_from_deflated(&self.0.deref().data)
             .finish(&sc.serialize_settings());
@@ -50,7 +56,7 @@ impl<const C: u8> Cacheable for ICCProfile<C> {
         icc_profile.n(C as i32).range([0.0, 1.0].repeat(C as usize));
         icc_stream.write_filters(icc_profile.deref_mut().deref_mut());
         icc_profile.finish();
-        sc.chunk_container.icc_profiles.push(chunk);
+        chunk_container.icc_profiles.push(chunk);
     }
 }
 
@@ -72,11 +78,16 @@ impl GenericICCProfile {
 }
 
 impl Cacheable for GenericICCProfile {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         match self {
-            GenericICCProfile::Luma(l) => l.serialize(sc, root_ref),
-            GenericICCProfile::Rgb(r) => r.serialize(sc, root_ref),
-            GenericICCProfile::Cmyk(c) => c.serialize(sc, root_ref),
+            GenericICCProfile::Luma(l) => l.serialize(sc, chunk_container, root_ref),
+            GenericICCProfile::Rgb(r) => r.serialize(sc, chunk_container, root_ref),
+            GenericICCProfile::Cmyk(c) => c.serialize(sc, chunk_container, root_ref),
         }
     }
 }
@@ -85,16 +96,20 @@ impl Cacheable for GenericICCProfile {
 pub(crate) struct ICCBasedColorSpace<const C: u8>(pub(crate) ICCProfile<C>);
 
 impl<const C: u8> Cacheable for ICCBasedColorSpace<C> {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
-        let icc_ref = sc.register_cacheable(self.0.clone());
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
+        let icc_ref = sc.register_cacheable(chunk_container, self.0.clone());
 
-        let mut chunk = Chunk::new();
+        let chunk = &mut chunk_container.color_spaces;
 
         let mut array = chunk.indirect(root_ref).array();
         array.item(Name(b"ICCBased"));
         array.item(icc_ref);
         array.finish();
-        sc.chunk_container.color_spaces.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/image.rs
+++ b/crates/krilla/src/graphics/image.rs
@@ -19,6 +19,7 @@ use png::{BitDepth, ColorType, Transformations};
 use zune_jpeg::zune_core::colorspace::ColorSpace;
 use zune_jpeg::JpegDecoder;
 
+use crate::chunk_container::ChunkContainer;
 use crate::configure::ValidationError;
 use crate::error::KrillaError;
 use crate::graphics::color::DEVICE_GRAY;
@@ -356,7 +357,12 @@ impl Image {
         self.0.color_space()
     }
 
-    pub(crate) fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
+    pub(crate) fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         let soft_mask_id = self.0.metadata.has_alpha.then(|| {
             sc.register_validation_error(ValidationError::Transparency(sc.location));
             sc.new_ref()
@@ -370,9 +376,15 @@ impl Image {
                 && self.color_space().matches_icc_profile(&ic)
             {
                 let ref_ = match ic {
-                    GenericICCProfile::Luma(l) => sc.register_cacheable(ICCBasedColorSpace(l)),
-                    GenericICCProfile::Rgb(r) => sc.register_cacheable(ICCBasedColorSpace(r)),
-                    GenericICCProfile::Cmyk(c) => sc.register_cacheable(ICCBasedColorSpace(c)),
+                    GenericICCProfile::Luma(l) => {
+                        sc.register_cacheable(chunk_container, ICCBasedColorSpace(l))
+                    }
+                    GenericICCProfile::Rgb(r) => {
+                        sc.register_cacheable(chunk_container, ICCBasedColorSpace(r))
+                    }
+                    GenericICCProfile::Cmyk(c) => {
+                        sc.register_cacheable(chunk_container, ICCBasedColorSpace(c))
+                    }
                 };
 
                 Some(ref_)
@@ -406,7 +418,7 @@ impl Image {
                 },
             };
 
-            sc.register_colorspace(cs)
+            sc.register_colorspace(chunk_container, cs)
         };
 
         let supports_bit_depth = sc
@@ -498,7 +510,7 @@ impl Image {
             Ok(chunk)
         });
 
-        sc.chunk_container.images.push(chunk);
+        chunk_container.images.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/mask.rs
+++ b/crates/krilla/src/graphics/mask.rs
@@ -1,7 +1,8 @@
 //! Alpha and luminosity masks.
 
-use pdf_writer::{Chunk, Finish, Name, Ref};
+use pdf_writer::{Finish, Name, Ref};
 
+use crate::chunk_container::ChunkContainer;
 use crate::geom::{Rect, Transform};
 use crate::graphics::shading_function::{GradientProperties, ShadingFunction};
 use crate::graphics::xobject::XObject;
@@ -46,6 +47,7 @@ impl Mask {
         shading_transform: Transform,
         bbox: Rect,
         serializer_context: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
     ) -> Option<Self> {
         match &gradient_properties {
             GradientProperties::RadialAxialGradient(rag) => {
@@ -63,7 +65,7 @@ impl Mask {
         let shading_function = ShadingFunction::new(gradient_properties, true);
 
         let shading_stream = {
-            let mut builder = StreamBuilder::new(serializer_context);
+            let mut builder = StreamBuilder::new(serializer_context, chunk_container);
             let mut surface = builder.surface();
             surface.push_transform(&shading_transform);
             surface.draw_shading(&shading_function);
@@ -100,19 +102,24 @@ impl MaskType {
 }
 
 impl Cacheable for Mask {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
-        let mut chunk = Chunk::new();
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
+        let x_object = sc.register_cacheable(
+            chunk_container,
+            XObject::new(self.stream, false, true, self.custom_bbox),
+        );
 
-        let x_object =
-            sc.register_cacheable(XObject::new(self.stream, false, true, self.custom_bbox));
-
+        let chunk = &mut chunk_container.masks;
         let mut dict = chunk.indirect(root_ref).dict();
         dict.pair(Name(b"Type"), Name(b"Mask"));
         dict.pair(Name(b"S"), self.mask_type.to_name());
         dict.pair(Name(b"G"), x_object);
 
         dict.finish();
-        sc.chunk_container.masks.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/separation.rs
+++ b/crates/krilla/src/graphics/separation.rs
@@ -1,6 +1,7 @@
 use pdf_writer::writers::ExponentialFunction;
-use pdf_writer::{Chunk, Finish, Name, Ref, Writer};
+use pdf_writer::{Finish, Name, Ref, Writer};
 
+use crate::chunk_container::ChunkContainer;
 use crate::color::separation::SeparationSpace;
 use crate::color::{DEVICE_CMYK, DEVICE_GRAY, DEVICE_RGB};
 use crate::resource::{self, Resource, Resourceable};
@@ -18,10 +19,15 @@ impl SeparationColorSpace {
 }
 
 impl Cacheable for SeparationColorSpace {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         // Delegate fallback color space registration to existing logic
         let fallback_cs = self.space.fallback.color_space(sc);
-        let fallback_cs_resource = sc.register_colorspace(fallback_cs.into());
+        let fallback_cs_resource = sc.register_colorspace(chunk_container, fallback_cs.into());
 
         // Get fallback color components for tint function
         let fallback_color = crate::color::Color::from(self.space.fallback).to_pdf_color();
@@ -40,7 +46,7 @@ impl Cacheable for SeparationColorSpace {
             sc.register_validation_error(validation_error);
         }
 
-        let mut chunk = Chunk::new();
+        let chunk = &mut chunk_container.color_spaces;
 
         // Write Separation color space array: [/Separation name alternateSpace tintTransform]
         let mut array = chunk.indirect(root_ref).array();
@@ -72,8 +78,6 @@ impl Cacheable for SeparationColorSpace {
             .n(1.0);
 
         array.finish();
-
-        sc.chunk_container.color_spaces.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/shading_function.rs
+++ b/crates/krilla/src/graphics/shading_function.rs
@@ -7,16 +7,17 @@ use pdf_writer::types::{FunctionShadingType, PostScriptOp};
 use pdf_writer::{Chunk, Finish, Ref};
 use tiny_skia_path::Point;
 
+use crate::chunk_container::ChunkContainer;
 use crate::configure::ValidationError;
 use crate::geom::{Rect, Transform};
 use crate::graphics::color::luma;
-use crate::graphics::color::Color;
+use crate::graphics::color::{Color, ColorSpace};
 use crate::graphics::paint::{LinearGradient, RadialGradient, SweepGradient};
 use crate::graphics::paint::{SpreadMethod, Stop};
 use crate::num::NormalizedF32;
 use crate::resource;
 use crate::resource::Resourceable;
-use crate::serialize::{Cacheable, SerializeContext};
+use crate::serialize::{Cacheable, MaybeDeviceColorSpace, SerializeContext};
 use crate::util::set_colorspace;
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
@@ -224,37 +225,62 @@ impl ShadingFunction {
 }
 
 impl Cacheable for ShadingFunction {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
-        let mut chunk = Chunk::new();
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         let mut stream_chunk = Chunk::new();
 
         match &self.0.properties {
             GradientProperties::RadialAxialGradient(rag) => {
-                serialize_axial_radial_shading(sc, &mut chunk, root_ref, rag, self.0.use_opacities)
+                let shading_cs =
+                    shading_color_space(sc, rag.stops[0].color.clone(), self.0.use_opacities);
+                let registered_cs = sc.register_colorspace(chunk_container, shading_cs);
+                let chunk = &mut chunk_container.shading_functions;
+                serialize_axial_radial_shading(
+                    sc,
+                    chunk,
+                    root_ref,
+                    rag,
+                    self.0.use_opacities,
+                    registered_cs,
+                )
             }
             GradientProperties::PostScriptGradient(psg) => {
                 sc.register_validation_error(ValidationError::ContainsPostScript(sc.location));
+                let shading_cs =
+                    shading_color_space(sc, psg.stops[0].color.clone(), self.0.use_opacities);
+                let registered_cs = sc.register_colorspace(chunk_container, shading_cs);
+                let chunk = &mut chunk_container.shading_functions;
                 serialize_postscript_shading(
                     sc,
-                    &mut chunk,
+                    chunk,
                     &mut stream_chunk,
                     root_ref,
                     psg,
                     self.0.use_opacities,
+                    registered_cs,
                 )
             }
         }
 
-        sc.chunk_container.shading_functions.push(chunk);
         // Note: The stream chunk might be empty.
-        sc.chunk_container
-            .shading_function_streams
-            .push(stream_chunk);
+        chunk_container.shading_function_streams.push(stream_chunk);
     }
 }
 
 impl Resourceable for ShadingFunction {
     type Resource = resource::Shading;
+}
+
+fn shading_color_space(sc: &mut SerializeContext, color: Color, use_opacities: bool) -> ColorSpace {
+    if use_opacities {
+        luma::color_space(sc.serialize_settings().no_device_cs).into()
+    } else {
+        color.color_space(sc)
+    }
 }
 
 fn serialize_postscript_shading(
@@ -264,22 +290,17 @@ fn serialize_postscript_shading(
     root_ref: Ref,
     post_script_gradient: &PostScriptGradient,
     use_opacities: bool,
+    cs: MaybeDeviceColorSpace,
 ) {
     let domain = post_script_gradient.domain;
 
     let bump = Bump::new();
     let function_ref =
         select_postscript_function(post_script_gradient, stream_chunk, sc, &bump, use_opacities);
-    let cs = if use_opacities {
-        luma::color_space(sc.serialize_settings().no_device_cs).into()
-    } else {
-        post_script_gradient.stops[0].color.color_space(sc)
-    };
-
     let mut shading = chunk.function_shading(root_ref);
     shading.shading_type(FunctionShadingType::Function);
 
-    set_colorspace(sc.register_colorspace(cs), shading.deref_mut());
+    set_colorspace(cs, shading.deref_mut());
 
     // Write the identity matrix, because ghostscript has a bug where
     // it thinks the entry is mandatory.
@@ -297,15 +318,10 @@ fn serialize_axial_radial_shading(
     root_ref: Ref,
     radial_axial_gradient: &RadialAxialGradient,
     use_opacities: bool,
+    cs: MaybeDeviceColorSpace,
 ) {
     let function_ref =
         select_axial_radial_function(radial_axial_gradient, chunk, sc, use_opacities);
-    let cs = if use_opacities {
-        luma::color_space(sc.serialize_settings().no_device_cs).into()
-    } else {
-        radial_axial_gradient.stops[0].color.color_space(sc)
-    };
-
     let mut shading = chunk.function_shading(root_ref);
     if radial_axial_gradient.shading_type == FunctionShadingType::Radial {
         shading.shading_type(FunctionShadingType::Radial);
@@ -313,7 +329,7 @@ fn serialize_axial_radial_shading(
         shading.shading_type(FunctionShadingType::Axial);
     }
 
-    set_colorspace(sc.register_colorspace(cs), shading.deref_mut());
+    set_colorspace(cs, shading.deref_mut());
 
     shading.anti_alias(radial_axial_gradient.anti_alias);
     shading.function(function_ref);

--- a/crates/krilla/src/graphics/shading_pattern.rs
+++ b/crates/krilla/src/graphics/shading_pattern.rs
@@ -1,8 +1,9 @@
 use std::hash::Hash;
 use std::sync::Arc;
 
-use pdf_writer::{Chunk, Finish, Name, Ref};
+use pdf_writer::{Finish, Name, Ref};
 
+use crate::chunk_container::ChunkContainer;
 use crate::geom::Transform;
 use crate::graphics::shading_function::{GradientProperties, ShadingFunction};
 use crate::resource;
@@ -38,16 +39,19 @@ impl ShadingPattern {
 }
 
 impl Cacheable for ShadingPattern {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
-        let mut chunk = Chunk::new();
-
-        let shading_ref = sc.register_cacheable(self.0.shading_function.clone());
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
+        let shading_ref = sc.register_cacheable(chunk_container, self.0.shading_function.clone());
+        let chunk = &mut chunk_container.patterns;
         let mut shading_pattern = chunk.shading_pattern(root_ref);
         shading_pattern.pair(Name(b"Shading"), shading_ref);
         shading_pattern.matrix(self.0.shading_transform.to_pdf_transform());
 
         shading_pattern.finish();
-        sc.chunk_container.patterns.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/tiling_pattern.rs
+++ b/crates/krilla/src/graphics/tiling_pattern.rs
@@ -6,6 +6,7 @@ use std::ops::DerefMut;
 use pdf_writer::types::{PaintType, TilingType};
 use pdf_writer::{Chunk, Finish, Ref};
 
+use crate::chunk_container::ChunkContainer;
 use crate::geom::Transform;
 use crate::num::NormalizedF32;
 use crate::resource;
@@ -43,6 +44,7 @@ impl TilingPattern {
         width: f32,
         height: f32,
         serializer_context: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
     ) -> Self {
         // stroke/fill opacity doesn't work consistently across different viewers for patterns,
         // so instead we simulate it ourselves.
@@ -50,7 +52,7 @@ impl TilingPattern {
             stream
         } else {
             let stream = {
-                let mut builder = StreamBuilder::new(serializer_context);
+                let mut builder = StreamBuilder::new(serializer_context, chunk_container);
                 let mut surface = builder.surface();
                 surface.draw_opacified_stream(base_opacity, stream);
                 surface.finish();
@@ -71,7 +73,12 @@ impl TilingPattern {
 }
 
 impl Cacheable for TilingPattern {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         let mut chunk = Chunk::new();
 
         for validation_error in self.stream.validation_errors {
@@ -101,7 +108,7 @@ impl Cacheable for TilingPattern {
             .y_step(final_bbox.y2 - final_bbox.y1);
 
         tiling_pattern.finish();
-        sc.chunk_container.pattern_streams.push(chunk);
+        chunk_container.pattern_streams.push(chunk);
     }
 }
 

--- a/crates/krilla/src/graphics/xobject.rs
+++ b/crates/krilla/src/graphics/xobject.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use pdf_writer::{Chunk, Finish, Name, Ref};
 
+use crate::chunk_container::ChunkContainer;
 use crate::configure::ValidationError;
 use crate::geom::Rect;
 use crate::graphics::color::{rgb, DEVICE_RGB};
@@ -60,7 +61,12 @@ impl XObject {
 }
 
 impl Cacheable for XObject {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         let mut chunk = Chunk::new();
 
         for validation_error in &self.0.stream.validation_errors {
@@ -83,7 +89,10 @@ impl Cacheable for XObject {
         // So while we don't technically always need to write it, let's just play it save
         // and always add a group color space in case we have a transparency group.
         let transparency_group_cs = if use_transparency_group {
-            Some(sc.register_colorspace(rgb::color_space(serialize_settings.no_device_cs).into()))
+            Some(sc.register_colorspace(
+                chunk_container,
+                rgb::color_space(serialize_settings.no_device_cs).into(),
+            ))
         } else {
             None
         };
@@ -131,7 +140,7 @@ impl Cacheable for XObject {
         }
 
         x_object.finish();
-        sc.chunk_container.x_objects.push(chunk);
+        chunk_container.x_objects.push(chunk);
     }
 }
 

--- a/crates/krilla/src/interactive/annotation.rs
+++ b/crates/krilla/src/interactive/annotation.rs
@@ -9,8 +9,9 @@
 use core::f32;
 
 use pdf_writer::types::AnnotationFlags;
-use pdf_writer::{Chunk, Finish, Name, Ref, TextStr};
+use pdf_writer::{Finish, Name, Ref, TextStr};
 
+use crate::chunk_container::ChunkContainer;
 use crate::color::Color;
 use crate::configure::{PdfVersion, ValidationError};
 use crate::geom::{Quadrilateral, Rect};
@@ -61,8 +62,14 @@ impl From<LinkAnnotation> for Annotation {
 }
 
 impl Annotation {
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root_ref: Ref, page_height: f32) {
-        let mut chunk = Chunk::new();
+    pub(crate) fn serialize(
+        &self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+        page_height: f32,
+    ) {
+        let chunk = &mut chunk_container.annotations;
         let mut annotation = chunk
             .indirect(root_ref)
             .start::<pdf_writer::writers::Annotation>();
@@ -99,7 +106,6 @@ impl Annotation {
         }
 
         annotation.finish();
-        sc.chunk_container.annotations.push(chunk);
     }
 }
 

--- a/crates/krilla/src/interactive/destination.rs
+++ b/crates/krilla/src/interactive/destination.rs
@@ -8,9 +8,10 @@
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use pdf_writer::{Chunk, Obj, Ref, Str};
+use pdf_writer::{Obj, Ref, Str};
 use tiny_skia_path::Transform;
 
+use crate::chunk_container::ChunkContainer;
 use crate::geom::Point;
 use crate::serialize::{PageInfo, SerializeContext};
 
@@ -111,8 +112,13 @@ impl XyzDestination {
         Self(Arc::new(XyzDestRepr { page_index, point }))
     }
 
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root_ref: Ref) {
-        let mut chunk = Chunk::new();
+    pub(crate) fn serialize(
+        &self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
+        let chunk = &mut chunk_container.destinations;
         let destination = chunk.destination(root_ref);
 
         let page_info = sc.page_infos().get(self.0.page_index).unwrap_or_else(|| {
@@ -141,6 +147,5 @@ impl XyzDestination {
         destination
             .page(page_ref)
             .xyz(mapped_point.x, mapped_point.y, None);
-        sc.chunk_container.destinations.push(chunk);
     }
 }

--- a/crates/krilla/src/interchange/embed.rs
+++ b/crates/krilla/src/interchange/embed.rs
@@ -4,6 +4,7 @@ use std::ops::DerefMut;
 
 use pdf_writer::{Chunk, Finish, Name, Ref, Str, TextStr};
 
+use crate::chunk_container::ChunkContainer;
 use crate::configure::{PdfVersion, ValidationError};
 use crate::interchange::metadata::pdf_date;
 use crate::metadata::DateTime;
@@ -51,13 +52,18 @@ pub struct EmbeddedFile {
 }
 
 impl Cacheable for EmbeddedFile {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         sc.register_validation_error(ValidationError::EmbeddedFile(
             EmbedError::Existence,
             self.location,
         ));
 
-        let mut chunk = Chunk::new();
+        let chunk = &mut chunk_container.embedded_files;
         let mut stream_chunk = Chunk::new();
         let stream_ref = sc.new_ref();
 
@@ -131,8 +137,7 @@ impl Cacheable for EmbeddedFile {
         }
 
         file_spec.finish();
-        sc.chunk_container.embedded_files.push(chunk);
-        sc.chunk_container.embedded_file_streams.push(stream_chunk);
+        chunk_container.embedded_file_streams.push(stream_chunk);
     }
 }
 

--- a/crates/krilla/src/interchange/outline.rs
+++ b/crates/krilla/src/interchange/outline.rs
@@ -21,6 +21,7 @@
 use pdf_writer::writers::OutlineItem;
 use pdf_writer::{Chunk, Finish, Name, Ref, TextStr};
 
+use crate::chunk_container::ChunkContainer;
 use crate::interactive::destination::XyzDestination;
 use crate::serialize::SerializeContext;
 
@@ -108,7 +109,12 @@ impl Outline {
         self.children.push(node)
     }
 
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root: Ref) {
+    pub(crate) fn serialize(
+        &self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root: Ref,
+    ) {
         let mut chunk = Chunk::new();
         let children = serialize_children(&self.children, root, &mut chunk, sc);
 
@@ -118,7 +124,7 @@ impl Outline {
         }
         outline.finish();
 
-        sc.chunk_container.outline = Some((root, chunk));
+        chunk_container.outline = Some((root, chunk));
     }
 }
 

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -136,6 +136,7 @@ use pdf_writer::writers::{PropertyList, StructElement};
 use pdf_writer::{Chunk, Finish, Name, Ref, Str, TextStr};
 use smallvec::SmallVec;
 
+use crate::chunk_container::ChunkContainer;
 use crate::configure::{PdfVersion, ValidationError};
 use crate::error::{KrillaError, KrillaResult};
 use crate::page::page_root_transform;
@@ -1034,6 +1035,7 @@ impl TagTree {
     pub(crate) fn serialize(
         &self,
         sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
         parent_tree_map: &mut HashMap<IdentifierType, Ref>,
         id_tree_map: &mut BTreeMap<TagId, Ref>,
         struct_tree_ref: Ref,
@@ -1080,7 +1082,7 @@ impl TagTree {
         )?;
 
         struct_elem.finish();
-        sc.chunk_container.struct_elements = Some(struct_elems);
+        chunk_container.struct_elements = Some(struct_elems);
 
         Ok(root_ref)
     }

--- a/crates/krilla/src/page.rs
+++ b/crates/krilla/src/page.rs
@@ -8,6 +8,7 @@ use pdf_writer::types::TabOrder;
 use pdf_writer::writers::NumberTree;
 use pdf_writer::{Chunk, Finish, Ref, TextStr};
 
+use crate::chunk_container::ChunkContainer;
 use crate::configure::PdfVersion;
 use crate::content::ContentBuilder;
 use crate::geom::{Rect, Size, Transform};
@@ -186,6 +187,7 @@ impl Default for PageSettings {
 /// [`Document::start_page`]: crate::Document::start_page
 pub struct Page<'a> {
     sc: &'a mut SerializeContext,
+    chunk_container: &'a mut ChunkContainer,
     page_settings: PageSettings,
     page_index: usize,
     page_stream: Stream,
@@ -196,11 +198,13 @@ pub struct Page<'a> {
 impl<'a> Page<'a> {
     pub(crate) fn new(
         sc: &'a mut SerializeContext,
+        chunk_container: &'a mut ChunkContainer,
         page_index: usize,
         page_settings: PageSettings,
     ) -> Self {
         Self {
             sc,
+            chunk_container,
             page_settings,
             page_index,
             num_mcids: 0,
@@ -251,7 +255,13 @@ impl<'a> Page<'a> {
             None
         };
 
-        Surface::new(self.sc, root_builder, page_identifier, finish_fn)
+        Surface::new(
+            self.sc,
+            self.chunk_container,
+            root_builder,
+            page_identifier,
+            finish_fn,
+        )
     }
 
     /// A shorthand for `std::mem::drop`.
@@ -366,20 +376,29 @@ impl InternalPage {
         }
     }
 
-    pub(crate) fn serialize(self, sc: &mut SerializeContext, root_ref: Ref) {
-        let mut chunk = Chunk::new();
-
+    pub(crate) fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         let mut annotation_refs = vec![];
 
         if !self.annotations.is_empty() {
             for annotation in &self.annotations {
                 let annot_ref = sc.new_ref();
 
-                annotation.serialize(sc, annot_ref, self.page_settings.surface_size().height());
+                annotation.serialize(
+                    sc,
+                    chunk_container,
+                    annot_ref,
+                    self.page_settings.surface_size().height(),
+                );
                 annotation_refs.push((annot_ref, OnceCell::new()));
             }
         }
 
+        let chunk = &mut chunk_container.pages;
         let mut page = chunk.page(root_ref);
         self.stream_resources
             .to_pdf_resources(&mut page, sc.serialize_settings().pdf_version());
@@ -442,8 +461,7 @@ impl InternalPage {
         *annotations = annotation_refs;
 
         page.finish();
-        sc.chunk_container.pages.push(chunk);
-        sc.chunk_container.page_streams.push(self.stream_chunk);
+        chunk_container.page_streams.push(self.stream_chunk);
     }
 }
 
@@ -476,8 +494,8 @@ impl PageLabel {
         self.style.is_none() && self.prefix.is_none() && self.offset.is_none()
     }
 
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root_ref: Ref) {
-        let mut chunk = Chunk::new();
+    pub(crate) fn serialize(&self, chunk_container: &mut ChunkContainer, root_ref: Ref) {
+        let chunk = &mut chunk_container.page_labels;
         let mut label = chunk
             .indirect(root_ref)
             .start::<pdf_writer::writers::PageLabel>();
@@ -495,7 +513,6 @@ impl PageLabel {
         }
 
         label.finish();
-        sc.chunk_container.page_labels.push(chunk);
     }
 }
 
@@ -513,7 +530,12 @@ impl<'a> PageLabelContainer<'a> {
         }
     }
 
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root_ref: Ref) {
+    pub(crate) fn serialize(
+        &self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         // Will always contain at least one entry, since we ensured that a PageLabelContainer cannot
         // be empty
         let mut filtered_entries = vec![];
@@ -539,12 +561,12 @@ impl<'a> PageLabelContainer<'a> {
         let mut nums = num_tree.nums();
 
         for (page_num, label) in filtered_entries {
-            let label_ref = sc.register_page_label(label);
+            let label_ref = sc.register_page_label(chunk_container, label);
             nums.insert(page_num as i32, label_ref);
         }
 
         nums.finish();
         num_tree.finish();
-        sc.chunk_container.page_label_tree = Some((root_ref, chunk));
+        chunk_container.page_label_tree = Some((root_ref, chunk));
     }
 }

--- a/crates/krilla/src/pdf.rs
+++ b/crates/krilla/src/pdf.rs
@@ -13,7 +13,7 @@ use pdf_writer::{Name, Ref};
 
 pub use hayro_write::hayro_syntax::Pdf;
 
-use crate::chunk_container::EmbeddedPdfChunk;
+use crate::chunk_container::{ChunkContainer, EmbeddedPdfChunk};
 use crate::configure::{PdfVersion, ValidationError};
 use crate::error::{KrillaError, KrillaResult};
 use crate::graphics::color::rgb;
@@ -142,7 +142,11 @@ impl PdfSerializerContext {
         ref_
     }
 
-    pub(crate) fn serialize(self, sc: &mut SerializeContext) -> KrillaResult<()> {
+    pub(crate) fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+    ) -> KrillaResult<()> {
         let page_tree_parent_ref = sc.page_tree_ref();
         let krilla_version = sc.serialize_settings().configuration.version();
 
@@ -160,9 +164,10 @@ impl PdfSerializerContext {
             // but we just always allocate it if we have at least one PDF,
             // regardless of how the files are embedded. We can change this in the
             // future, but it keeps the code simpler.
-            let xobject_group_color_space = sc
-                .register_colorspace(rgb::color_space(sc.serialize_settings().no_device_cs).into());
-            let container = &mut sc.chunk_container;
+            let xobject_group_color_space = sc.register_colorspace(
+                chunk_container,
+                rgb::color_space(sc.serialize_settings().no_device_cs).into(),
+            );
 
             let deferred_chunk = Deferred::new(move || {
                 // We can't share the serializer context between threads, so each PDF has it's own
@@ -250,7 +255,7 @@ impl PdfSerializerContext {
                 })
             });
 
-            container.embedded_pdfs.push(deferred_chunk);
+            chunk_container.embedded_pdfs.push(deferred_chunk);
         }
 
         Ok(())

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -23,7 +23,6 @@ use crate::graphics::image::Image;
 use crate::graphics::separation::SeparationColorSpace;
 use crate::interactive::destination::{NamedDestination, XyzDestination};
 use crate::interchange::embed::EmbeddedFile;
-use crate::interchange::metadata::Metadata;
 use crate::interchange::outline::Outline;
 use crate::interchange::tagging::{AnnotationIdentifier, PageTagIdentifier, TagTree};
 use crate::page::{InternalPage, PageLabel, PageLabelContainer};
@@ -246,8 +245,6 @@ pub(crate) struct SerializeContext {
     /// is based on this field) to generate a new Ref, instead of creating one manually with
     /// `Ref::new`.
     pub(crate) cur_ref: Ref,
-    /// Collect all chunks that are generated as part of the PDF writing process.
-    pub(crate) chunk_container: ChunkContainer,
     /// All validation errors that are collected as part of the export process.
     validation_errors: Vec<ValidationError>,
     /// Settings used for serialization.
@@ -284,7 +281,6 @@ impl SerializeContext {
             pdf2_ns,
             global_objects: GlobalObjects::default(),
             cur_ref,
-            chunk_container: ChunkContainer::new(),
             page_tree_ref,
             page_infos: vec![],
             location: None,
@@ -324,13 +320,13 @@ impl SerializeContext {
         self.location = None
     }
 
-    pub(crate) fn set_metadata(&mut self, metadata: Metadata) {
-        self.chunk_container.metadata = Some(metadata);
-    }
-
-    pub(crate) fn embed_file(&mut self, file: EmbeddedFile) -> Option<()> {
+    pub(crate) fn embed_file(
+        &mut self,
+        chunk_container: &mut ChunkContainer,
+        file: EmbeddedFile,
+    ) -> Option<()> {
         let name = file.path.clone();
-        let ref_ = self.register_cacheable(file);
+        let ref_ = self.register_cacheable(chunk_container, file);
         if self
             .global_objects
             .embedded_files
@@ -410,31 +406,28 @@ impl SerializeContext {
         &mut self.validation_store
     }
 
-    pub(crate) fn finish(mut self) -> KrillaResult<Pdf> {
+    pub(crate) fn finish(mut self, mut chunk_container: ChunkContainer) -> KrillaResult<Pdf> {
         // We need to be careful here that we serialize the objects in the right order,
         // as in some cases we use MaybeTake::take to remove an object, which means that
         // no object that is serialized afterwards must depend on it.
 
         // Serialize all objects that can only be written in the end.
-        self.serialize_destination_profiles();
-        self.serialize_page_label_tree();
-        self.serialize_outline();
-        self.serialize_fonts()?;
-        self.serialize_pages()?;
-        self.serialize_page_tree();
+        self.serialize_destination_profiles(&mut chunk_container);
+        self.serialize_page_label_tree(&mut chunk_container);
+        self.serialize_outline(&mut chunk_container);
+        self.serialize_fonts(&mut chunk_container)?;
+        self.serialize_pages(&mut chunk_container)?;
+        self.serialize_page_tree(&mut chunk_container);
         #[cfg(feature = "pdf")]
-        self.serialize_embedded_pdfs()?;
-        self.serialize_xyz_destinations()?;
+        self.serialize_embedded_pdfs(&mut chunk_container)?;
+        self.serialize_xyz_destinations(&mut chunk_container)?;
         // It is important that we serialize the tags AFTER we have serialized the pages,
         // because page serialization will update the annotation refs of the page infos,
         // and when serializing the parent tree map we need to know the refs of the annotations
-        self.serialize_tag_tree()?;
+        self.serialize_tag_tree(&mut chunk_container)?;
 
         // Create the final PDF.
-        let pdf = {
-            let chunk_container = std::mem::take(&mut self.chunk_container);
-            chunk_container.finish(&mut self)?
-        };
+        let pdf = chunk_container.finish(&mut self)?;
         self.register_limits(pdf.limits());
 
         self.check_validator_limits();
@@ -544,38 +537,54 @@ impl SerializeContext {
         }
     }
 
-    pub(crate) fn register_cacheable<T>(&mut self, object: T) -> Ref
+    pub(crate) fn register_cacheable<T>(
+        &mut self,
+        chunk_container: &mut ChunkContainer,
+        object: T,
+    ) -> Ref
     where
         T: Cacheable,
     {
         self.register_cached(object, |sc, object, root_ref| {
-            object.serialize(sc, root_ref);
+            object.serialize(sc, chunk_container, root_ref);
         })
     }
 
-    pub(crate) fn register_resourceable<T>(&mut self, object: T) -> T::Resource
+    pub(crate) fn register_resourceable<T>(
+        &mut self,
+        chunk_container: &mut ChunkContainer,
+        object: T,
+    ) -> T::Resource
     where
         T: Resourceable,
     {
-        Resource::new(self.register_cacheable(object))
+        Resource::new(self.register_cacheable(chunk_container, object))
     }
 
     #[cfg(feature = "raster-images")]
-    pub(crate) fn register_image(&mut self, image: Image) -> Ref {
+    pub(crate) fn register_image(
+        &mut self,
+        chunk_container: &mut ChunkContainer,
+        image: Image,
+    ) -> Ref {
         self.register_cached(image, |sc, object, root_ref| {
-            object.serialize(sc, root_ref);
+            object.serialize(sc, chunk_container, root_ref);
         })
     }
 
     pub(crate) fn register_xyz_destination(&mut self, dest: XyzDestination) -> Ref {
-        self.register_cached(dest, |sc, object, root_ref| {
-            sc.global_objects.xyz_destinations.push((root_ref, object));
+        self.register_cached(dest, |sc, dest, root_ref| {
+            sc.global_objects.xyz_destinations.push((root_ref, dest));
         })
     }
 
-    pub(crate) fn register_page_label(&mut self, page_label: PageLabel) -> Ref {
+    pub(crate) fn register_page_label(
+        &mut self,
+        chunk_container: &mut ChunkContainer,
+        page_label: PageLabel,
+    ) -> Ref {
         let ref_ = self.new_ref();
-        page_label.serialize(self, ref_);
+        page_label.serialize(chunk_container, ref_);
         ref_
     }
 
@@ -590,27 +599,33 @@ impl SerializeContext {
         }
     }
 
-    pub(crate) fn register_colorspace(&mut self, cs: ColorSpace) -> MaybeDeviceColorSpace {
+    pub(crate) fn register_colorspace(
+        &mut self,
+        chunk_container: &mut ChunkContainer,
+        cs: ColorSpace,
+    ) -> MaybeDeviceColorSpace {
         match cs {
             ColorSpace::CieBased(CieBasedColorSpace::Srgb) => {
-                MaybeDeviceColorSpace::ColorSpace(self.register_resourceable(ICCBasedColorSpace(
-                    self.serialize_settings.pdf_version().rgb_icc(),
-                )))
+                MaybeDeviceColorSpace::ColorSpace(self.register_resourceable(
+                    chunk_container,
+                    ICCBasedColorSpace(self.serialize_settings.pdf_version().rgb_icc()),
+                ))
             }
             ColorSpace::CieBased(CieBasedColorSpace::Luma) => {
-                MaybeDeviceColorSpace::ColorSpace(self.register_resourceable(ICCBasedColorSpace(
-                    self.serialize_settings.pdf_version().grey_icc(),
-                )))
+                MaybeDeviceColorSpace::ColorSpace(self.register_resourceable(
+                    chunk_container,
+                    ICCBasedColorSpace(self.serialize_settings.pdf_version().grey_icc()),
+                ))
             }
             ColorSpace::CieBased(CieBasedColorSpace::Cmyk(cs)) => {
-                MaybeDeviceColorSpace::ColorSpace(self.register_resourceable(cs))
+                MaybeDeviceColorSpace::ColorSpace(self.register_resourceable(chunk_container, cs))
             }
             ColorSpace::Device(DeviceColorSpace::Gray) => MaybeDeviceColorSpace::DeviceGray,
             ColorSpace::Device(DeviceColorSpace::Rgb) => MaybeDeviceColorSpace::DeviceRgb,
             ColorSpace::Device(DeviceColorSpace::Cmyk) => MaybeDeviceColorSpace::DeviceCMYK,
             ColorSpace::Special(SpecialColorSpace::Separation(s)) => {
                 MaybeDeviceColorSpace::ColorSpace(
-                    self.register_resourceable(SeparationColorSpace::new(s)),
+                    self.register_resourceable(chunk_container, SeparationColorSpace::new(s)),
                 )
             }
         }
@@ -620,9 +635,9 @@ impl SerializeContext {
 /// Various serialization methods.
 /// All methods are supposed to only be called once in `SerializeContext::finish`!
 impl SerializeContext {
-    fn serialize_destination_profiles(&mut self) {
+    fn serialize_destination_profiles(&mut self, chunk_container: &mut ChunkContainer) {
         let validator = self.serialize_settings.validator();
-        self.chunk_container.destination_profiles = validator.output_intent().map(|subtype| {
+        chunk_container.destination_profiles = validator.output_intent().map(|subtype| {
             let root_ref = self.new_ref();
             let mut chunk = Chunk::new();
 
@@ -630,7 +645,7 @@ impl SerializeContext {
             let mut oi = chunk.indirect(oi_ref).start::<OutputIntent>();
             let icc_profile = self.serialize_settings.pdf_version().rgb_icc();
 
-            oi.dest_output_profile(self.register_cacheable(icc_profile.clone()))
+            oi.dest_output_profile(self.register_cacheable(chunk_container, icc_profile.clone()))
                 .subtype(subtype)
                 .output_condition_identifier(TextStr("Custom"))
                 .output_condition(TextStr("sRGB"))
@@ -653,7 +668,7 @@ impl SerializeContext {
         });
     }
 
-    fn serialize_page_label_tree(&mut self) {
+    fn serialize_page_label_tree(&mut self, chunk_container: &mut ChunkContainer) {
         if let Some(container) = PageLabelContainer::new(
             &self
                 .page_infos
@@ -662,28 +677,31 @@ impl SerializeContext {
                 .collect::<Vec<_>>(),
         ) {
             let page_label_tree_ref = self.new_ref();
-            container.serialize(self, page_label_tree_ref);
+            container.serialize(self, chunk_container, page_label_tree_ref);
         }
     }
 
-    fn serialize_outline(&mut self) {
+    fn serialize_outline(&mut self, chunk_container: &mut ChunkContainer) {
         let outline = self.global_objects.outline.take();
         if let Some(outline) = &outline {
             let outline_ref = self.new_ref();
-            outline.serialize(self, outline_ref);
+            outline.serialize(self, chunk_container, outline_ref);
         } else {
             self.register_validation_error(ValidationError::MissingDocumentOutline);
         }
     }
 
     #[cfg(feature = "pdf")]
-    fn serialize_embedded_pdfs(&mut self) -> KrillaResult<()> {
+    fn serialize_embedded_pdfs(
+        &mut self,
+        chunk_container: &mut ChunkContainer,
+    ) -> KrillaResult<()> {
         let pdf_ctx = self.global_objects.pdf_ctx.take();
 
-        pdf_ctx.serialize(self)
+        pdf_ctx.serialize(self, chunk_container)
     }
 
-    fn serialize_fonts(&mut self) -> KrillaResult<()> {
+    fn serialize_fonts(&mut self, chunk_container: &mut ChunkContainer) -> KrillaResult<()> {
         let fonts = self.global_objects.font_map.take();
         for font_container in fonts.values() {
             let borrowed = font_container.borrow();
@@ -691,47 +709,52 @@ impl SerializeContext {
             if !borrowed.type3_mapper().is_empty() {
                 for t3_font in borrowed.type3_mapper().fonts() {
                     let f = self.register_font_identifier(t3_font.identifier());
-                    t3_font.serialize(self, f.get_ref());
+                    t3_font.serialize(self, chunk_container, f.get_ref());
                 }
             }
 
             if !borrowed.cid_font().is_empty() {
                 let f = self.register_font_identifier(borrowed.cid_font().identifier());
-                borrowed.cid_font().serialize(self, f.get_ref())?;
+                borrowed
+                    .cid_font()
+                    .serialize(self, chunk_container, f.get_ref())?;
             }
         }
 
         Ok(())
     }
 
-    fn serialize_pages(&mut self) -> KrillaResult<()> {
+    fn serialize_pages(&mut self, chunk_container: &mut ChunkContainer) -> KrillaResult<()> {
         let pages = self.global_objects.pages.take();
         for (ref_, page) in pages {
-            page.serialize(self, ref_);
+            page.serialize(self, chunk_container, ref_);
         }
 
         Ok(())
     }
 
-    fn serialize_page_tree(&mut self) {
+    fn serialize_page_tree(&mut self, chunk_container: &mut ChunkContainer) {
         let mut page_tree_chunk = Chunk::new();
         page_tree_chunk
             .pages(self.page_tree_ref)
             .count(self.page_infos.len() as i32)
             .kids(self.page_infos.iter().map(|i| i.ref_()));
-        self.chunk_container.page_tree = Some((self.page_tree_ref, page_tree_chunk));
+        chunk_container.page_tree = Some((self.page_tree_ref, page_tree_chunk));
     }
 
-    fn serialize_xyz_destinations(&mut self) -> KrillaResult<()> {
+    fn serialize_xyz_destinations(
+        &mut self,
+        chunk_container: &mut ChunkContainer,
+    ) -> KrillaResult<()> {
         let xyz_destinations = self.global_objects.xyz_destinations.take();
         for (ref_, dest) in &xyz_destinations {
-            dest.serialize(self, *ref_);
+            dest.serialize(self, chunk_container, *ref_);
         }
 
         Ok(())
     }
 
-    fn serialize_tag_tree(&mut self) -> KrillaResult<()> {
+    fn serialize_tag_tree(&mut self, chunk_container: &mut ChunkContainer) -> KrillaResult<()> {
         let tag_tree = self.global_objects.tag_tree.take();
         let struct_parents = self.global_objects.struct_parents.take();
         if let Some(root) = &tag_tree {
@@ -740,6 +763,7 @@ impl SerializeContext {
             let struct_tree_root_ref = self.new_ref();
             let document_ref = root.serialize(
                 self,
+                chunk_container,
                 &mut parent_tree_map,
                 &mut id_tree_map,
                 struct_tree_root_ref,
@@ -857,7 +881,7 @@ impl SerializeContext {
                 chunk.extend(&sub_chunk);
             }
 
-            self.chunk_container.struct_tree_root = Some((struct_tree_root_ref, chunk));
+            chunk_container.struct_tree_root = Some((struct_tree_root_ref, chunk));
         } else {
             self.register_validation_error(ValidationError::MissingTagging);
         }
@@ -1015,5 +1039,10 @@ impl GlobalObjects {
 }
 
 pub(crate) trait Cacheable: SipHashable {
-    fn serialize(self, sc: &mut SerializeContext, root_ref: Ref);
+    fn serialize(
+        self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    );
 }

--- a/crates/krilla/src/stream.rs
+++ b/crates/krilla/src/stream.rs
@@ -31,6 +31,7 @@ use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use pdf_writer::{Array, Dict, Name};
 
+use crate::chunk_container::ChunkContainer;
 use crate::configure::ValidationError;
 use crate::content::ContentBuilder;
 use crate::geom::{Rect, Transform};
@@ -91,13 +92,18 @@ impl Stream {
 /// A builder to create streams.
 pub struct StreamBuilder<'a> {
     sc: &'a mut SerializeContext,
+    chunk_container: &'a mut ChunkContainer,
     stream: Stream,
 }
 
 impl<'a> StreamBuilder<'a> {
-    pub(crate) fn new(sc: &'a mut SerializeContext) -> Self {
+    pub(crate) fn new(
+        sc: &'a mut SerializeContext,
+        chunk_container: &'a mut ChunkContainer,
+    ) -> Self {
         Self {
             sc,
+            chunk_container,
             stream: Stream::empty(),
         }
     }
@@ -112,6 +118,7 @@ impl<'a> StreamBuilder<'a> {
 
         Surface::new(
             self.sc,
+            self.chunk_container,
             ContentBuilder::new(Transform::identity(), true),
             None,
             finish_fn,

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -6,6 +6,7 @@
 
 use std::num::NonZeroU64;
 
+use crate::chunk_container::ChunkContainer;
 use crate::color::rgb;
 use crate::content::ContentBuilder;
 use crate::geom::Path;
@@ -68,6 +69,7 @@ pub type Location = NonZeroU64;
 /// [`Page::surface`]: crate::page::Page::surface
 pub struct Surface<'a> {
     pub(crate) sc: &'a mut SerializeContext,
+    pub(crate) chunk_container: &'a mut ChunkContainer,
     fill: Option<Fill>,
     stroke: Option<Stroke>,
     bd: Builders,
@@ -79,12 +81,14 @@ pub struct Surface<'a> {
 impl<'a> Surface<'a> {
     pub(crate) fn new(
         sc: &'a mut SerializeContext,
+        chunk_container: &'a mut ChunkContainer,
         root_builder: ContentBuilder,
         page_identifier: Option<PageTagIdentifier>,
         finish_fn: Box<dyn FnMut(Stream, i32) + 'a>,
     ) -> Surface<'a> {
         Self {
             sc,
+            chunk_container,
             bd: Builders::new(root_builder),
             page_identifier,
             fill: None,
@@ -96,7 +100,7 @@ impl<'a> Surface<'a> {
 
     /// Return a `StreamBuilder` to allow drawing on a sub-context.
     pub fn stream_builder(&mut self) -> StreamBuilder<'_> {
-        StreamBuilder::new(self.sc)
+        StreamBuilder::new(self.sc, self.chunk_container)
     }
 
     /// Set the fill that should be used for the next drawing operation.
@@ -129,25 +133,38 @@ impl<'a> Surface<'a> {
     pub fn draw_path(&mut self, path: &Path) {
         if self.fill.is_some() || self.stroke.is_some() {
             if self.has_complex_fill_or_stroke() {
-                self.bd
-                    .get_mut()
-                    .draw_path(&path.0, self.fill.as_ref(), None, self.sc);
-                self.bd
-                    .get_mut()
-                    .draw_path(&path.0, None, self.stroke.as_ref(), self.sc);
+                self.bd.get_mut().draw_path(
+                    &path.0,
+                    self.fill.as_ref(),
+                    None,
+                    self.sc,
+                    self.chunk_container,
+                );
+                self.bd.get_mut().draw_path(
+                    &path.0,
+                    None,
+                    self.stroke.as_ref(),
+                    self.sc,
+                    self.chunk_container,
+                );
             } else {
                 self.bd.get_mut().draw_path(
                     &path.0,
                     self.fill.as_ref(),
                     self.stroke.as_ref(),
                     self.sc,
+                    self.chunk_container,
                 );
             }
         } else {
             // Draw with black by default.
-            self.bd
-                .get_mut()
-                .draw_path(&path.0, Some(&Fill::default()), None, self.sc);
+            self.bd.get_mut().draw_path(
+                &path.0,
+                Some(&Fill::default()),
+                None,
+                self.sc,
+                self.chunk_container,
+            );
         }
     }
 
@@ -276,6 +293,7 @@ impl<'a> Surface<'a> {
                         self.bd.get_mut().draw_glyphs(
                             start,
                             self.sc,
+                            self.chunk_container,
                             Some(f),
                             None,
                             context_color,
@@ -290,6 +308,7 @@ impl<'a> Surface<'a> {
                         self.bd.get_mut().draw_glyphs(
                             start,
                             self.sc,
+                            self.chunk_container,
                             Some(f),
                             Some(s),
                             context_color,
@@ -304,6 +323,7 @@ impl<'a> Surface<'a> {
                     self.bd.get_mut().draw_glyphs(
                         start,
                         self.sc,
+                        self.chunk_container,
                         None,
                         Some(s),
                         context_color,
@@ -317,6 +337,7 @@ impl<'a> Surface<'a> {
                     self.bd.get_mut().draw_glyphs(
                         start,
                         self.sc,
+                        self.chunk_container,
                         Some(f),
                         None,
                         context_color,
@@ -331,6 +352,7 @@ impl<'a> Surface<'a> {
                     self.bd.get_mut().draw_glyphs(
                         start,
                         self.sc,
+                        self.chunk_container,
                         Some(&Fill::default()),
                         None,
                         context_color,
@@ -437,6 +459,7 @@ impl<'a> Surface<'a> {
 
         self.bd.get_mut().draw_xobject_by_reference(
             self.sc,
+            self.chunk_container,
             Rect::from_xywh(0.0, 0.0, page_width, page_height).unwrap(),
             obj_ref,
         );
@@ -479,18 +502,24 @@ impl<'a> Surface<'a> {
             PushInstruction::Opacity(o) => {
                 if o != NormalizedF32::ONE {
                     let stream = self.bd.sub_builders.pop().unwrap().finish(self.sc);
-                    self.bd.get_mut().draw_opacified(self.sc, o, stream);
+                    self.bd
+                        .get_mut()
+                        .draw_opacified(self.sc, self.chunk_container, o, stream);
                 }
             }
             PushInstruction::ClipPath => self.bd.get_mut().pop_clip_path(),
             PushInstruction::BlendMode => self.bd.get_mut().restore_graphics_state(),
             PushInstruction::Mask(mask) => {
                 let stream = self.bd.sub_builders.pop().unwrap().finish(self.sc);
-                self.bd.get_mut().draw_masked(self.sc, *mask, stream)
+                self.bd
+                    .get_mut()
+                    .draw_masked(self.sc, self.chunk_container, *mask, stream)
             }
             PushInstruction::Isolated => {
                 let stream = self.bd.sub_builders.pop().unwrap().finish(self.sc);
-                self.bd.get_mut().draw_isolated(self.sc, stream);
+                self.bd
+                    .get_mut()
+                    .draw_isolated(self.sc, self.chunk_container, stream);
             }
         }
     }
@@ -498,7 +527,9 @@ impl<'a> Surface<'a> {
     #[cfg(feature = "raster-images")]
     /// Draw a new bitmap image.
     pub fn draw_image(&mut self, image: Image, size: Size) {
-        self.bd.get_mut().draw_image(image, size, self.sc);
+        self.bd
+            .get_mut()
+            .draw_image(image, size, self.sc, self.chunk_container);
     }
 
     /// Draw a new graphic.
@@ -506,13 +537,18 @@ impl<'a> Surface<'a> {
     /// Drawing the same graphic multiple times is very cheap in terms of
     /// file size.
     pub fn draw_graphic(&mut self, graphic: Graphic) {
-        self.bd
-            .get_mut()
-            .draw_xobject(self.sc, graphic.x_object, &ExtGState::new())
+        self.bd.get_mut().draw_xobject(
+            self.sc,
+            self.chunk_container,
+            graphic.x_object,
+            &ExtGState::new(),
+        )
     }
 
     pub(crate) fn draw_shading(&mut self, shading: &ShadingFunction) {
-        self.bd.get_mut().draw_shading(shading, self.sc);
+        self.bd
+            .get_mut()
+            .draw_shading(shading, self.sc, self.chunk_container);
     }
 
     /// A convenience method for `std::mem::drop`.
@@ -522,7 +558,9 @@ impl<'a> Surface<'a> {
     pub fn finish(self) {}
 
     pub(crate) fn draw_opacified_stream(&mut self, opacity: NormalizedF32, stream: Stream) {
-        self.bd.get_mut().draw_opacified(self.sc, opacity, stream)
+        self.bd
+            .get_mut()
+            .draw_opacified(self.sc, self.chunk_container, opacity, stream)
     }
 
     /// Return the current transformation matrix of the surface.

--- a/crates/krilla/src/text/cid.rs
+++ b/crates/krilla/src/text/cid.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use subsetter::GlyphRemapper;
 
 use super::{CIDIdentifier, FontIdentifier, PDF_UNITS_PER_EM};
+use crate::chunk_container::ChunkContainer;
 use crate::configure::ValidationError;
 use crate::error::{KrillaError, KrillaResult};
 use crate::geom::Rect;
@@ -183,8 +184,13 @@ impl CIDFont {
         FontIdentifier::Cid(CIDIdentifier(self.font.clone()))
     }
 
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root_ref: Ref) -> KrillaResult<()> {
-        let mut chunk = Chunk::new();
+    pub(crate) fn serialize(
+        &self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) -> KrillaResult<()> {
+        let chunk = &mut chunk_container.fonts;
         let mut stream_chunk = Chunk::new();
 
         let cid_ref = sc.new_ref();
@@ -394,8 +400,7 @@ impl CIDFont {
         }
 
         stream.finish();
-        sc.chunk_container.fonts.push(chunk);
-        sc.chunk_container.font_streams.push(stream_chunk);
+        chunk_container.font_streams.push(stream_chunk);
 
         Ok(())
     }

--- a/crates/krilla/src/text/type3.rs
+++ b/crates/krilla/src/text/type3.rs
@@ -8,6 +8,7 @@ use pdf_writer::{Chunk, Content, Finish, Name, Ref, Str};
 use rustc_hash::FxHashMap;
 
 use super::{FontIdentifier, Type3Identifier};
+use crate::chunk_container::ChunkContainer;
 use crate::color::rgb;
 use crate::configure::PdfVersion;
 use crate::geom::Path;
@@ -127,8 +128,12 @@ impl Type3Font {
         FontIdentifier::Type3(Type3Identifier(self.font.clone(), self.index))
     }
 
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, root_ref: Ref) {
-        let mut chunk = Chunk::new();
+    pub(crate) fn serialize(
+        &self,
+        sc: &mut SerializeContext,
+        chunk_container: &mut ChunkContainer,
+        root_ref: Ref,
+    ) {
         let mut stream_chunk = Chunk::new();
 
         let mut rd_builder = ResourceDictionaryBuilder::new();
@@ -139,7 +144,7 @@ impl Type3Font {
             .iter()
             .enumerate()
             .map(|(index, glyph)| {
-                let mut stream_surface = StreamBuilder::new(sc);
+                let mut stream_surface = StreamBuilder::new(sc, chunk_container);
                 let mut surface = stream_surface.surface();
 
                 // In case this returns `None`, the surface is guaranteed to be empty.
@@ -185,7 +190,8 @@ impl Type3Font {
                 let x_object = XObject::new(stream, false, false, None);
                 if !x_object.is_empty() {
                     font_bbox.expand(&x_object.bbox());
-                    let x_name = rd_builder.register_resource(sc.register_resourceable(x_object));
+                    let x_name = rd_builder
+                        .register_resource(sc.register_resourceable(chunk_container, x_object));
                     content.x_object(x_name.to_pdf_name());
                 }
 
@@ -206,6 +212,7 @@ impl Type3Font {
             .collect::<Vec<Ref>>();
 
         let resource_dictionary = rd_builder.finish();
+        let chunk = &mut chunk_container.fonts;
 
         let descriptor_ref = if sc.serialize_settings().pdf_version() >= PdfVersion::Pdf15 {
             Some(sc.new_ref())
@@ -362,8 +369,7 @@ impl Type3Font {
         let mut cmap = stream_chunk.cmap(cmap_ref, &cmap_stream);
         cmap.writing_mode(WMode::Horizontal);
         cmap.finish();
-        sc.chunk_container.fonts.push(chunk);
-        sc.chunk_container.font_streams.push(stream_chunk);
+        chunk_container.font_streams.push(stream_chunk);
     }
 }
 


### PR DESCRIPTION
Instead of letting each (non-stream) field store a `Vec<Chunk>`, we use one single chunk per category and let the serializer functions write directly into it.

Unfortunately, in the original design this would cause lots of borrowing issues. To work around that, `ChunkContainer` is now stored inside of `Document` instead of `SerializeContext` and passed as a separate field wherever necessary. This does make some method signatures more messy, but the alternatives I tried were even messier.