### PR TITLE
Don't use indirect object for empty resource dictionaries

### DIFF
--- a/crates/krilla/src/resource.rs
+++ b/crates/krilla/src/resource.rs
@@ -247,11 +247,28 @@ impl ResourceDictionary {
     ) where
         T: ResourcesExt,
     {
+        let write_proc_sets = !sc.serialize_settings().pdf_version().deprecates_proc_sets();
+        let has_resource_entries = self.color_spaces.len() > 0
+            || self.ext_g_states.len() > 0
+            || self.patterns.len() > 0
+            || self.x_objects.len() > 0
+            || self.shadings.len() > 0
+            || self.fonts.len() > 0;
+
+        if !write_proc_sets && !has_resource_entries {
+            // `Resources` dictionary is mandatory (or rather, it's mandatory if
+            // there isn't a parent resource dictionary to inherit from, but we just
+            // assume it is always mandatory), so just write an empty one as a direct
+            // object instead of an indirect object, for aesthetic reasons.
+            parent.resources().finish();
+            return;
+        }
+
         let resources_ref = sc.new_ref();
         let mut resources = resources_chunk
             .indirect(resources_ref)
             .start::<writers::Resources>();
-        if !sc.serialize_settings().pdf_version().deprecates_proc_sets() {
+        if write_proc_sets {
             resources.proc_sets([
                 ProcSet::Pdf,
                 ProcSet::Text,
@@ -364,34 +381,55 @@ where
 }
 
 pub(crate) trait ResourcesExt {
+    fn resources(&mut self) -> writers::Resources<'_>;
     fn set_resources(&mut self, resources_ref: Ref);
 }
 
 impl ResourcesExt for writers::FormXObject<'_> {
+    fn resources(&mut self) -> writers::Resources<'_> {
+        self.resources()
+    }
+
     fn set_resources(&mut self, resources_ref: Ref) {
         self.pair(Name(b"Resources"), resources_ref);
     }
 }
 
 impl ResourcesExt for writers::TilingPattern<'_> {
+    fn resources(&mut self) -> writers::Resources<'_> {
+        self.resources()
+    }
+
     fn set_resources(&mut self, resources_ref: Ref) {
         self.pair(Name(b"Resources"), resources_ref);
     }
 }
 
 impl ResourcesExt for writers::Type3Font<'_> {
+    fn resources(&mut self) -> writers::Resources<'_> {
+        self.resources()
+    }
+
     fn set_resources(&mut self, resources_ref: Ref) {
         self.pair(Name(b"Resources"), resources_ref);
     }
 }
 
 impl ResourcesExt for writers::Pages<'_> {
+    fn resources(&mut self) -> writers::Resources<'_> {
+        self.resources()
+    }
+
     fn set_resources(&mut self, resources_ref: Ref) {
         self.pair(Name(b"Resources"), resources_ref);
     }
 }
 
 impl ResourcesExt for writers::Page<'_> {
+    fn resources(&mut self) -> writers::Resources<'_> {
+        self.resources()
+    }
+
     fn set_resources(&mut self, resources_ref: Ref) {
         self.pair(Name(b"Resources"), resources_ref);
     }

--- a/refs/snapshots/embedded_file_pdf_20.txt
+++ b/refs/snapshots/embedded_file_pdf_20.txt
@@ -5,38 +5,34 @@
 <<
   /Type /Pages
   /Count 1
-  /Kids [3 0 R]
+  /Kids [2 0 R]
 >>
 endobj
 
 2 0 obj
-<<>>
-endobj
-
-3 0 obj
 <<
   /Type /Page
-  /Resources 2 0 R
+  /Resources <<>>
   /MediaBox [0 0 595 842]
   /Parent 1 0 R
-  /Contents 5 0 R
+  /Contents 4 0 R
 >>
 endobj
 
-4 0 obj
+3 0 obj
 <<
   /Type /Filespec
   /F (emojis.txt)
   /UF (emojis.txt)
   /EF <<
-    /F 6 0 R
-    /UF 6 0 R
+    /F 5 0 R
+    /UF 5 0 R
   >>
   /Desc (The description of the file.)
 >>
 endobj
 
-5 0 obj
+4 0 obj
 <<
   /Length 0
 >>
@@ -45,7 +41,7 @@ stream
 endstream
 endobj
 
-6 0 obj
+5 0 obj
 <<
   /Length 209
   /Type /EmbeddedFile
@@ -60,44 +56,43 @@ stream
 endstream
 endobj
 
-7 0 obj
+6 0 obj
 <<
   /ModDate (D:20010101000000Z)
   /CreationDate (D:20010101000000Z)
 >>
 endobj
 
-8 0 obj
+7 0 obj
 <<
   /Type /Catalog
   /Pages 1 0 R
   /Lang (en)
   /Names <<
     /EmbeddedFiles <<
-      /Names [(emojis.txt) 4 0 R]
+      /Names [(emojis.txt) 3 0 R]
     >>
   >>
 >>
 endobj
 
 xref
-0 9
+0 8
 0000000000 65535 f
 0000000016 00000 n
 0000000080 00000 n
-0000000101 00000 n
-0000000216 00000 n
-0000000373 00000 n
-0000000425 00000 n
-0000000798 00000 n
-0000000887 00000 n
+0000000194 00000 n
+0000000351 00000 n
+0000000403 00000 n
+0000000776 00000 n
+0000000865 00000 n
 trailer
 <<
-  /Size 9
-  /Root 8 0 R
-  /Info 7 0 R
-  /ID [(pT4drWR3NanvIx6thErq1w==) (pT4drWR3NanvIx6thErq1w==)]
+  /Size 8
+  /Root 7 0 R
+  /Info 6 0 R
+  /ID [(kNLadNU8kraOHmC4T/13rg==) (kNLadNU8kraOHmC4T/13rg==)]
 >>
 startxref
-1034
+1012
 %%EOF

--- a/refs/snapshots/metadata_pdf_20_author.txt
+++ b/refs/snapshots/metadata_pdf_20_author.txt
@@ -5,25 +5,21 @@
 <<
   /Type /Pages
   /Count 1
-  /Kids [3 0 R]
+  /Kids [2 0 R]
 >>
 endobj
 
 2 0 obj
-<<>>
-endobj
-
-3 0 obj
 <<
   /Type /Page
-  /Resources 2 0 R
+  /Resources <<>>
   /MediaBox [0 0 595 842]
   /Parent 1 0 R
-  /Contents 4 0 R
+  /Contents 3 0 R
 >>
 endobj
 
-4 0 obj
+3 0 obj
 <<
   /Length 0
 >>
@@ -32,49 +28,48 @@ stream
 endstream
 endobj
 
-5 0 obj
+4 0 obj
 <<
   /ModDate (D:20241108222318+01'12)
   /CreationDate (D:20241108222318+01'12)
 >>
 endobj
 
-6 0 obj
+5 0 obj
 <<
   /Length 984
   /Type /Metadata
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:creator><rdf:Seq><rdf:li>John Doe</rdf:li><rdf:li>Max Mustermann</rdf:li></rdf:Seq></dc:creator><xmp:ModifyDate>2024-11-08T22:23:18+01:12</xmp:ModifyDate><xmp:CreateDate>2024-11-08T22:23:18+01:12</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>kpGmAhfJkipiTroI+VkPmg==</xmpMM:InstanceID><xmpMM:DocumentID>kpGmAhfJkipiTroI+VkPmg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>2.0</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:creator><rdf:Seq><rdf:li>John Doe</rdf:li><rdf:li>Max Mustermann</rdf:li></rdf:Seq></dc:creator><xmp:ModifyDate>2024-11-08T22:23:18+01:12</xmp:ModifyDate><xmp:CreateDate>2024-11-08T22:23:18+01:12</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>MwwFglmw0BSz8PWEY/ZfSg==</xmpMM:InstanceID><xmpMM:DocumentID>MwwFglmw0BSz8PWEY/ZfSg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>2.0</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
-7 0 obj
+6 0 obj
 <<
   /Type /Catalog
   /Pages 1 0 R
-  /Metadata 6 0 R
+  /Metadata 5 0 R
 >>
 endobj
 
 xref
-0 8
+0 7
 0000000000 65535 f
 0000000016 00000 n
 0000000080 00000 n
-0000000101 00000 n
-0000000216 00000 n
-0000000268 00000 n
-0000000367 00000 n
-0000001439 00000 n
+0000000194 00000 n
+0000000246 00000 n
+0000000345 00000 n
+0000001417 00000 n
 trailer
 <<
-  /Size 8
-  /Root 7 0 R
-  /Info 5 0 R
-  /ID [(kpGmAhfJkipiTroI+VkPmg==) (kpGmAhfJkipiTroI+VkPmg==)]
+  /Size 7
+  /Root 6 0 R
+  /Info 4 0 R
+  /ID [(MwwFglmw0BSz8PWEY/ZfSg==) (MwwFglmw0BSz8PWEY/ZfSg==)]
 >>
 startxref
-1511
+1489
 %%EOF

--- a/refs/snapshots/pdf_20.txt
+++ b/refs/snapshots/pdf_20.txt
@@ -5,25 +5,21 @@
 <<
   /Type /Pages
   /Count 1
-  /Kids [3 0 R]
+  /Kids [2 0 R]
 >>
 endobj
 
 2 0 obj
-<<>>
-endobj
-
-3 0 obj
 <<
   /Type /Page
-  /Resources 2 0 R
+  /Resources <<>>
   /MediaBox [0 0 595 842]
   /Parent 1 0 R
-  /Contents 4 0 R
+  /Contents 3 0 R
 >>
 endobj
 
-4 0 obj
+3 0 obj
 <<
   /Length 0
 >>
@@ -32,14 +28,14 @@ stream
 endstream
 endobj
 
-5 0 obj
+4 0 obj
 <<
   /ModDate (D:20241108222318+01'12)
   /CreationDate (D:20241108222318+01'12)
 >>
 endobj
 
-6 0 obj
+5 0 obj
 <<
   /Type /Catalog
   /Pages 1 0 R
@@ -52,21 +48,20 @@ endobj
 endobj
 
 xref
-0 7
+0 6
 0000000000 65535 f
 0000000016 00000 n
 0000000080 00000 n
-0000000101 00000 n
-0000000216 00000 n
-0000000268 00000 n
-0000000367 00000 n
+0000000194 00000 n
+0000000246 00000 n
+0000000345 00000 n
 trailer
 <<
-  /Size 7
-  /Root 6 0 R
-  /Info 5 0 R
-  /ID [(F1CF232GUzEL/FGeYRuxqw==) (kpGmAhfJkipiTroI+VkPmg==)]
+  /Size 6
+  /Root 5 0 R
+  /Info 4 0 R
+  /ID [(F1CF232GUzEL/FGeYRuxqw==) (MwwFglmw0BSz8PWEY/ZfSg==)]
 >>
 startxref
-513
+491
 %%EOF

--- a/refs/snapshots/tagging_custom_namespace_pdf_20.txt
+++ b/refs/snapshots/tagging_custom_namespace_pdf_20.txt
@@ -5,7 +5,7 @@
 <<
   /Type /Pages
   /Count 1
-  /Kids [9 0 R]
+  /Kids [8 0 R]
 >>
 endobj
 
@@ -65,20 +65,16 @@ endobj
 endobj
 
 8 0 obj
-<<>>
-endobj
-
-9 0 obj
 <<
   /Type /Page
-  /Resources 8 0 R
+  /Resources <<>>
   /MediaBox [0 0 595 842]
   /Parent 1 0 R
-  /Contents 10 0 R
+  /Contents 9 0 R
 >>
 endobj
 
-10 0 obj
+9 0 obj
 <<
   /Length 66
 >>
@@ -96,7 +92,7 @@ Q
 endstream
 endobj
 
-11 0 obj
+10 0 obj
 <<
   /Type /Catalog
   /Pages 1 0 R
@@ -108,7 +104,7 @@ endobj
 endobj
 
 xref
-0 12
+0 11
 0000000000 65535 f
 0000000016 00000 n
 0000000080 00000 n
@@ -118,15 +114,14 @@ xref
 0000000487 00000 n
 0000000580 00000 n
 0000000661 00000 n
-0000000682 00000 n
-0000000798 00000 n
-0000000918 00000 n
+0000000775 00000 n
+0000000894 00000 n
 trailer
 <<
-  /Size 12
-  /Root 11 0 R
-  /ID [(cGrvJ/EcANUPQ8vfGpTVWQ==) (cGrvJ/EcANUPQ8vfGpTVWQ==)]
+  /Size 11
+  /Root 10 0 R
+  /ID [(y6mrL+D1AkY/9ofkQJ7VlA==) (y6mrL+D1AkY/9ofkQJ7VlA==)]
 >>
 startxref
-1034
+1010
 %%EOF

--- a/refs/snapshots/validate_pdf_a4_f_with_embedded_file.txt
+++ b/refs/snapshots/validate_pdf_a4_f_with_embedded_file.txt
@@ -5,14 +5,14 @@
 <<
   /Type /Pages
   /Count 1
-  /Kids [5 0 R]
+  /Kids [4 0 R]
 >>
 endobj
 
 2 0 obj
 <<
   /Type /OutputIntent
-  /DestOutputProfile 9 0 R
+  /DestOutputProfile 8 0 R
   /S /GTS_PDFA1
   /OutputConditionIdentifier (Custom)
   /OutputCondition (sRGB)
@@ -26,34 +26,30 @@ endobj
 endobj
 
 4 0 obj
-<<>>
-endobj
-
-5 0 obj
 <<
   /Type /Page
-  /Resources 4 0 R
+  /Resources <<>>
   /MediaBox [0 0 595 842]
   /Parent 1 0 R
-  /Contents 7 0 R
+  /Contents 6 0 R
 >>
 endobj
 
-6 0 obj
+5 0 obj
 <<
   /Type /Filespec
   /F (emojis.txt)
   /UF (emojis.txt)
   /EF <<
-    /F 8 0 R
-    /UF 8 0 R
+    /F 7 0 R
+    /UF 7 0 R
   >>
   /AFRelationship /Supplement
   /Desc (The description of the file.)
 >>
 endobj
 
-7 0 obj
+6 0 obj
 <<
   /Length 0
 >>
@@ -62,7 +58,7 @@ stream
 endstream
 endobj
 
-8 0 obj
+7 0 obj
 <<
   /Length 209
   /Type /EmbeddedFile
@@ -77,7 +73,7 @@ stream
 endstream
 endobj
 
-9 0 obj
+8 0 obj
 <<
   /Length 636
   /N 3
@@ -97,53 +93,52 @@ C843DBF35560A80CD51B53B7F4A6A5025DD90DA89FC34002866FC1BDF60DE3E25FB1
 endstream
 endobj
 
-10 0 obj
+9 0 obj
 <<
   /Length 3905
   /Type /Metadata
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2001-01-01T00:00:00Z</xmp:ModifyDate><xmp:CreateDate>2001-01-01T00:00:00Z</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2001-01-01T00:00:00Z</stEvt:when><stEvt:instanceID>F4wnG1qpF7bxlhtJMdA2/w==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2001-01-01T00:00:00Z</stEvt:when><stEvt:instanceID>F4wnG1qpF7bxlhtJMdA2/w==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>4</pdfaid:part><pdfaid:rev>2020</pdfaid:rev><pdfaid:conformance>F</pdfaid:conformance><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>F4wnG1qpF7bxlhtJMdA2/w==</xmpMM:InstanceID><xmpMM:DocumentID>F4wnG1qpF7bxlhtJMdA2/w==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>2.0</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2001-01-01T00:00:00Z</xmp:ModifyDate><xmp:CreateDate>2001-01-01T00:00:00Z</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2001-01-01T00:00:00Z</stEvt:when><stEvt:instanceID>1UjYylV1qCHV5ccMUdzfuA==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2001-01-01T00:00:00Z</stEvt:when><stEvt:instanceID>1UjYylV1qCHV5ccMUdzfuA==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>4</pdfaid:part><pdfaid:rev>2020</pdfaid:rev><pdfaid:conformance>F</pdfaid:conformance><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>1UjYylV1qCHV5ccMUdzfuA==</xmpMM:InstanceID><xmpMM:DocumentID>1UjYylV1qCHV5ccMUdzfuA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>2.0</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
-11 0 obj
+10 0 obj
 <<
   /Type /Catalog
   /Pages 1 0 R
-  /Metadata 10 0 R
+  /Metadata 9 0 R
   /OutputIntents 3 0 R
   /Lang (en)
   /Names <<
     /EmbeddedFiles <<
-      /Names [(emojis.txt) 6 0 R]
+      /Names [(emojis.txt) 5 0 R]
     >>
   >>
-  /AF [6 0 R]
+  /AF [5 0 R]
 >>
 endobj
 
 xref
-0 12
+0 11
 0000000000 65535 f
 0000000016 00000 n
 0000000080 00000 n
 0000000270 00000 n
 0000000294 00000 n
-0000000315 00000 n
-0000000430 00000 n
-0000000617 00000 n
-0000000669 00000 n
-0000001042 00000 n
-0000001803 00000 n
-0000005798 00000 n
+0000000408 00000 n
+0000000595 00000 n
+0000000647 00000 n
+0000001020 00000 n
+0000001781 00000 n
+0000005775 00000 n
 trailer
 <<
-  /Size 12
-  /Root 11 0 R
-  /ID [(F4wnG1qpF7bxlhtJMdA2/w==) (F4wnG1qpF7bxlhtJMdA2/w==)]
+  /Size 11
+  /Root 10 0 R
+  /ID [(1UjYylV1qCHV5ccMUdzfuA==) (1UjYylV1qCHV5ccMUdzfuA==)]
 >>
 startxref
-6002
+5978
 %%EOF


### PR DESCRIPTION
A follow-up to #375, since IMO empty dictionaries look quite ugly when written as an indirect object.