### PR TITLE
Reject named destinations with same name but different location

### DIFF
--- a/crates/krilla/src/chunk_container.rs
+++ b/crates/krilla/src/chunk_container.rs
@@ -307,10 +307,12 @@ impl ChunkContainer {
                     // self-consistent; keys shall be compared for equality on
                     // a simple byte-by-byte basis."
                     let mut sorted = named_destinations.into_iter().collect::<Vec<_>>();
-                    sorted.sort_by(|a, b| a.0.name.as_bytes().cmp(b.0.name.as_bytes()));
+                    // Note that named destinations are guaranteed to be unique,
+                    // hence just comparing by the name is enough.
+                    sorted.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
 
-                    for (name, dest_ref) in sorted {
-                        dest_name_entries.insert(Str(name.name.as_bytes()), remapper[&dest_ref]);
+                    for (name, (dest_ref, _)) in sorted {
+                        dest_name_entries.insert(Str(name.as_bytes()), remapper[&dest_ref]);
                     }
 
                     dest_name_entries.finish();

--- a/crates/krilla/src/document.rs
+++ b/crates/krilla/src/document.rs
@@ -129,8 +129,14 @@ impl Document {
     ///
     /// Named destinations used in link annotations are automatically registered, so you don't need
     /// to call this function for them.
-    pub fn register_named_destination(&mut self, dest: NamedDestination) {
-        self.serializer_context.register_named_destination(dest);
+    ///
+    /// Returns `None` if a named destination with the same name and a different destination has
+    /// already been registered, and therefore could not be registered again.
+    #[must_use]
+    pub fn register_named_destination(&mut self, dest: NamedDestination) -> Option<()> {
+        self.serializer_context
+            .register_named_destination(dest)
+            .map(|_| ())
     }
 
     /// Attempt to export the document to a PDF file.

--- a/crates/krilla/src/error.rs
+++ b/crates/krilla/src/error.rs
@@ -3,6 +3,8 @@
 //! There are a lot of things that can go wrong when writing a PDF, like for example when
 //! invalid fonts are provided. This module provides the basic error types krilla uses.
 
+use std::sync::Arc;
+
 use crate::configure::ValidationError;
 #[cfg(feature = "raster-images")]
 use crate::graphics::image::Image;
@@ -27,6 +29,9 @@ pub enum KrillaError {
     Validation(Vec<ValidationError>),
     /// A hard limit of the selected PDF version was exceeded.
     Limit(LimitError),
+    /// The same destination name has been associated with two different destinations,
+    /// which is prohibited.
+    DuplicateNamedDestination(Arc<String>),
     /// A duplicate [`Tag::id`] was provided.
     ///
     /// [`Tag::id`]: crate::interchange::tagging::Tag::id

--- a/crates/krilla/src/interactive/action.rs
+++ b/crates/krilla/src/interactive/action.rs
@@ -9,6 +9,7 @@
 use pdf_writer::types::ActionType;
 use pdf_writer::{Name, Str};
 
+use crate::error::KrillaResult;
 use crate::interactive::destination::Destination;
 use crate::serialize::SerializeContext;
 
@@ -25,9 +26,13 @@ impl Action {
         &self,
         sc: &mut SerializeContext,
         mut action: pdf_writer::writers::Action,
-    ) {
+    ) -> KrillaResult<()> {
         match self {
-            Action::Link(link) => link.serialize(action),
+            Action::Link(link) => {
+                link.serialize(action);
+                
+                Ok(())
+            }
             Action::Goto(dest) => {
                 let dest_entry = action.action_type(ActionType::GoTo).insert(Name(b"D"));
                 dest.serialize(sc, dest_entry)

--- a/crates/krilla/src/interactive/action.rs
+++ b/crates/krilla/src/interactive/action.rs
@@ -30,7 +30,7 @@ impl Action {
         match self {
             Action::Link(link) => {
                 link.serialize(action);
-                
+
                 Ok(())
             }
             Action::Goto(dest) => {

--- a/crates/krilla/src/interactive/annotation.rs
+++ b/crates/krilla/src/interactive/annotation.rs
@@ -14,6 +14,7 @@ use pdf_writer::{Finish, Name, Ref, TextStr};
 use crate::chunk_container::ChunkContainer;
 use crate::color::Color;
 use crate::configure::{PdfVersion, ValidationError};
+use crate::error::KrillaResult;
 use crate::geom::{Quadrilateral, Rect};
 use crate::interactive::action::Action;
 use crate::interactive::destination::Destination;
@@ -68,14 +69,14 @@ impl Annotation {
         chunk_container: &mut ChunkContainer,
         root_ref: Ref,
         page_height: f32,
-    ) {
+    ) -> KrillaResult<()> {
         let chunk = &mut chunk_container.non_stream.annotations;
         let mut annotation = chunk
             .indirect(root_ref)
             .start::<pdf_writer::writers::Annotation>();
 
         self.annotation_type
-            .serialize_type(sc, &mut annotation, page_height);
+            .serialize_type(sc, &mut annotation, page_height)?;
 
         let AnnotationType::Link(l) = &self.annotation_type;
         // Only set the print flag when really necessary (only PDF/A). Don't
@@ -106,6 +107,8 @@ impl Annotation {
         }
 
         annotation.finish();
+        
+        Ok(())
     }
 }
 
@@ -121,7 +124,7 @@ impl AnnotationType {
         sc: &mut SerializeContext,
         annotation: &mut pdf_writer::writers::Annotation,
         page_height: f32,
-    ) {
+    ) -> KrillaResult<()> {
         match self {
             AnnotationType::Link(l) => l.serialize_type(sc, annotation, page_height),
         }
@@ -229,7 +232,7 @@ impl LinkAnnotation {
         sc: &mut SerializeContext,
         annotation: &mut pdf_writer::writers::Annotation,
         page_height: f32,
-    ) {
+    ) -> KrillaResult<()> {
         annotation.subtype(pdf_writer::types::AnnotationType::Link);
 
         let actual_rect = self

--- a/crates/krilla/src/interactive/annotation.rs
+++ b/crates/krilla/src/interactive/annotation.rs
@@ -107,7 +107,7 @@ impl Annotation {
         }
 
         annotation.finish();
-        
+
         Ok(())
     }
 }

--- a/crates/krilla/src/interactive/destination.rs
+++ b/crates/krilla/src/interactive/destination.rs
@@ -12,6 +12,7 @@ use pdf_writer::{Obj, Ref, Str};
 use tiny_skia_path::Transform;
 
 use crate::chunk_container::ChunkContainer;
+use crate::error::{KrillaError, KrillaResult};
 use crate::geom::Point;
 use crate::serialize::{PageInfo, SerializeContext};
 
@@ -25,11 +26,13 @@ pub enum Destination {
 }
 
 impl Destination {
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, buffer: Obj) {
+    pub(crate) fn serialize(&self, sc: &mut SerializeContext, buffer: Obj) -> KrillaResult<()> {
         match self {
             Destination::Xyz(xyz) => {
                 let ref_ = sc.register_xyz_destination(xyz.clone());
                 buffer.primitive(ref_);
+
+                Ok(())
             }
             Destination::Named(named) => named.serialize(sc, buffer),
         }
@@ -64,9 +67,16 @@ impl NamedDestination {
         }
     }
 
-    pub(crate) fn serialize(&self, sc: &mut SerializeContext, destination: Obj) {
-        sc.register_named_destination(self.clone());
+    pub(crate) fn serialize(
+        &self,
+        sc: &mut SerializeContext,
+        destination: Obj,
+    ) -> KrillaResult<()> {
+        sc.register_named_destination(self.clone())
+            .ok_or_else(|| KrillaError::DuplicateNamedDestination(Arc::clone(&self.name)))?;
         destination.primitive(Str(self.name.as_bytes()));
+
+        Ok(())
     }
 }
 
@@ -147,5 +157,112 @@ impl XyzDestination {
         destination
             .page(page_ref)
             .xyz(mapped_point.x, mapped_point.y, None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::annotation::{LinkAnnotation, Target};
+    use crate::error::KrillaError;
+    use crate::geom::{Point, Rect};
+    use crate::Document;
+
+    use super::{NamedDestination, XyzDestination};
+
+    #[test]
+    fn named_duplicate_rejected() {
+        let mut document = Document::new();
+        assert_eq!(
+            document.register_named_destination(NamedDestination::new(
+                "same".to_string(),
+                XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
+            )),
+            Some(())
+        );
+        assert_eq!(
+            document.register_named_destination(NamedDestination::new(
+                "same".to_string(),
+                XyzDestination::new(0, Point::from_xy(100.0, 100.0)),
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn named_duplicate_annotation_rejected() {
+        let mut document = Document::new();
+        let mut page = document.start_page();
+
+        page.add_annotation(
+            LinkAnnotation::new(
+                Rect::from_xywh(0.0, 0.0, 100.0, 100.0).unwrap(),
+                Target::Destination(
+                    NamedDestination::new(
+                        "same".to_string(),
+                        XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
+                    )
+                    .into(),
+                ),
+            )
+            .into(),
+        );
+        page.add_annotation(
+            LinkAnnotation::new(
+                Rect::from_xywh(0.0, 100.0, 100.0, 100.0).unwrap(),
+                Target::Destination(
+                    NamedDestination::new(
+                        "same".to_string(),
+                        XyzDestination::new(0, Point::from_xy(100.0, 100.0)),
+                    )
+                    .into(),
+                ),
+            )
+            .into(),
+        );
+        drop(page);
+
+        assert_eq!(
+            document.finish(),
+            Err(KrillaError::DuplicateNamedDestination(Arc::new(
+                "same".to_string()
+            )))
+        );
+    }
+
+    #[test]
+    fn named_duplicate_manual_then_annotation_rejected() {
+        let mut document = Document::new();
+        assert_eq!(
+            document.register_named_destination(NamedDestination::new(
+                "same".to_string(),
+                XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
+            )),
+            Some(())
+        );
+
+        let mut page = document.start_page();
+        page.add_annotation(
+            LinkAnnotation::new(
+                Rect::from_xywh(0.0, 0.0, 100.0, 100.0).unwrap(),
+                Target::Destination(
+                    NamedDestination::new(
+                        "same".to_string(),
+                        XyzDestination::new(0, Point::from_xy(100.0, 100.0)),
+                    )
+                    .into(),
+                ),
+            )
+            .into(),
+        );
+        drop(page);
+
+        assert_eq!(
+            document.finish(),
+            Err(KrillaError::DuplicateNamedDestination(Arc::new(
+                "same".to_string()
+            )))
+        );
     }
 }

--- a/crates/krilla/src/interactive/destination.rs
+++ b/crates/krilla/src/interactive/destination.rs
@@ -191,6 +191,27 @@ mod tests {
     }
 
     #[test]
+    fn named_duplicate_same_location_allowed() {
+        let mut document = Document::new();
+        assert_eq!(
+            document.register_named_destination(NamedDestination::new(
+                "same".to_string(),
+                XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
+            )),
+            Some(())
+        );
+        assert_eq!(
+            document.register_named_destination(NamedDestination::new(
+                "same".to_string(),
+                XyzDestination::new(0, Point::from_xy(0.0, 0.0)),
+            )),
+            Some(())
+        );
+
+        assert!(document.finish().is_ok());
+    }
+
+    #[test]
     fn named_duplicate_annotation_rejected() {
         let mut document = Document::new();
         let mut page = document.start_page();

--- a/crates/krilla/src/page.rs
+++ b/crates/krilla/src/page.rs
@@ -11,6 +11,7 @@ use pdf_writer::{Chunk, Finish, Ref, TextStr};
 use crate::chunk_container::ChunkContainer;
 use crate::configure::PdfVersion;
 use crate::content::ContentBuilder;
+use crate::error::KrillaResult;
 use crate::geom::{Rect, Size, Transform};
 use crate::interactive::annotation::Annotation;
 use crate::interchange::tagging::{Identifier, PageTagIdentifier};
@@ -382,7 +383,7 @@ impl InternalPage {
         sc: &mut SerializeContext,
         chunk_container: &mut ChunkContainer,
         root_ref: Ref,
-    ) {
+    ) -> KrillaResult<()> {
         let mut annotation_refs = vec![];
 
         if !self.annotations.is_empty() {
@@ -394,7 +395,7 @@ impl InternalPage {
                     chunk_container,
                     annot_ref,
                     self.page_settings.surface_size().height(),
-                );
+                )?;
                 annotation_refs.push((annot_ref, OnceCell::new()));
             }
         }
@@ -466,6 +467,8 @@ impl InternalPage {
 
         page.finish();
         chunk_container.streams.pages.push(self.stream_chunk);
+        
+        Ok(())
     }
 }
 

--- a/crates/krilla/src/page.rs
+++ b/crates/krilla/src/page.rs
@@ -467,7 +467,7 @@ impl InternalPage {
 
         page.finish();
         chunk_container.streams.pages.push(self.stream_chunk);
-        
+
         Ok(())
     }
 }

--- a/crates/krilla/src/serialize.rs
+++ b/crates/krilla/src/serialize.rs
@@ -535,9 +535,18 @@ impl SerializeContext {
         }
     }
 
-    pub(crate) fn register_named_destination(&mut self, nd: NamedDestination) {
+    pub(crate) fn register_named_destination(&mut self, nd: NamedDestination) -> Option<Ref> {
+        if let Some((dest_ref, existing)) =
+            self.global_objects.named_destinations.get(nd.name.as_ref())
+        {
+            return (existing == nd.xyz_dest.as_ref()).then_some(*dest_ref);
+        }
+
         let dest_ref = self.register_xyz_destination((*nd.xyz_dest).clone());
-        self.global_objects.named_destinations.insert(nd, dest_ref);
+        self.global_objects
+            .named_destinations
+            .insert(nd.name.clone(), (dest_ref, (*nd.xyz_dest).clone()));
+        Some(dest_ref)
     }
 
     pub(crate) fn register_page(&mut self, page: InternalPage) {
@@ -761,7 +770,7 @@ impl SerializeContext {
     fn serialize_pages(&mut self, chunk_container: &mut ChunkContainer) -> KrillaResult<()> {
         let pages = self.global_objects.pages.take();
         for (ref_, page) in pages {
-            page.serialize(self, chunk_container, ref_);
+            page.serialize(self, chunk_container, ref_)?;
         }
 
         Ok(())
@@ -1027,9 +1036,10 @@ pub(crate) struct Pdf2Namespaces {
 
 #[derive(Default)]
 pub(crate) struct GlobalObjects {
-    /// All named destinations that have been registered, including a Ref to their destination.
+    /// All named destinations that have been registered, including a Ref to their destination and
+    /// the destination itself.
     // Needs to be pub(crate) because writing of named destinations happens in `ChunkContainer`.
-    pub(crate) named_destinations: MaybeTaken<HashMap<NamedDestination, Ref>>,
+    pub(crate) named_destinations: MaybeTaken<HashMap<Arc<String>, (Ref, XyzDestination)>>,
     /// A map from fonts to font container.
     font_map: MaybeTaken<IndexMap<Font, Rc<RefCell<FontContainer>>>>,
     /// All XYZ destinations used in the document. The reason we need to store them


### PR DESCRIPTION
Closes #309. I'm not sure if name trees technically allow something like this, but obviously it doesn't make sense to have the same name twice pointing to different locations. Therefore, we reject those.