### PR TITLE
Add invisible glyph text layer helper

### DIFF
--- a/crates/krilla/src/content.rs
+++ b/crates/krilla/src/content.rs
@@ -487,6 +487,36 @@ impl ContentBuilder {
         self.graphics_states.restore_state();
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn draw_invisible_glyphs(
+        &mut self,
+        start: Point,
+        sc: &mut SerializeContext,
+        context_color: rgb::Color,
+        glyphs: &[impl Glyph],
+        font: Font,
+        text: &str,
+        font_size: f32,
+    ) {
+        let (x, y) = (start.x, start.y);
+        self.graphics_states.save_state();
+
+        self.fill_stroke_glyph_run(
+            x,
+            y,
+            sc,
+            TextRenderingMode::Invisible,
+            |_, _| {},
+            glyphs,
+            font,
+            context_color,
+            text,
+            font_size,
+        );
+
+        self.graphics_states.restore_state();
+    }
+
     /// Encode a successive sequence of glyphs that share the same properties and
     /// can be encoded with one text showing operator.
     #[allow(clippy::too_many_arguments)]
@@ -787,7 +817,10 @@ impl ContentBuilder {
             .get_from_identifier(glyph_group.font_identifier.clone())
             .unwrap();
 
-        if fill_render_mode == TextRenderingMode::Fill || pdf_font.force_fill() {
+        if fill_render_mode == TextRenderingMode::Invisible {
+            self.content
+                .set_text_rendering_mode(TextRenderingMode::Invisible);
+        } else if fill_render_mode == TextRenderingMode::Fill || pdf_font.force_fill() {
             self.content
                 .set_text_rendering_mode(TextRenderingMode::Fill);
         } else if fill_render_mode == TextRenderingMode::FillStroke {

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -344,6 +344,28 @@ impl<'a> Surface<'a> {
         }
     }
 
+    /// Emit an invisible native PDF text layer for glyphs drawn through another path.
+    #[doc(hidden)]
+    pub fn draw_glyph_text_layer(
+        &mut self,
+        start: Point,
+        glyphs: &[impl Glyph],
+        font: Font,
+        text: &str,
+        font_size: f32,
+    ) {
+        let context_color = self.context_color();
+        self.bd.get_mut().draw_invisible_glyphs(
+            start,
+            self.sc,
+            context_color,
+            glyphs,
+            font,
+            text,
+            font_size,
+        );
+    }
+
     /// Draw some text using the currently active fill and/or stroke.
     ///
     /// This is a high-level method which allows you to just provide some text, which will


### PR DESCRIPTION
This adds a helper for writing a glyph run with PDF text rendering mode 3 (`Tr 3`), defined in ISO 32000-2 section 9.3.6 as “Neither fill nor stroke text (invisible)”.

That lets callers keep a text layer for copy/paste, search, ToUnicode mappings, and tagging even when the visible glyphs are drawn separately.
