### PR TITLE
Remove the recently introduced `try_` and `_once` methods

### DIFF
--- a/crates/krilla/src/configure/mod.rs
+++ b/crates/krilla/src/configure/mod.rs
@@ -40,60 +40,28 @@ impl ConfigurationBuilder {
         Self::default()
     }
 
-    /// Set the PDF version (overwrites if already set).
+    /// Set the PDF version, overwriting the current one if already set.
     pub fn with_version(mut self, version: PdfVersion) -> Self {
         self.version = Some(version);
         self
     }
 
-    /// Set the PDF version, returning `Err` with the existing value if one is already set.
-    pub fn try_with_version(mut self, version: PdfVersion) -> Result<Self, PdfVersion> {
-        match self.version {
-            Some(v) => Err(v),
-            None => {
-                self.version = Some(version);
-                Ok(self)
-            }
-        }
-    }
-
-    /// Set a validator (overwrites if same standard family already set).
+    /// Set a validator, overwriting the current one if the same standard family is already set.
     pub fn set_validator(mut self, validator: Validator) -> Self {
         self.validators = self.validators.set_validator(validator);
         self
     }
 
-    /// Set a validator, returning Err if that standard family is already set.
-    pub fn set_validator_once(mut self, validator: Validator) -> Result<Self, Validator> {
-        self.validators = self.validators.set_validator_once(validator)?;
-        Ok(self)
-    }
-
-    /// Set the PDF/A validator (overwrites if already set).
+    /// Set the PDF/A validator, overwriting the current one if already set.
     pub fn with_archival_validator(mut self, archival: Archival) -> Self {
         self.validators = self.validators.with_archival_validator(archival);
         self
     }
 
-    /// Set the PDF/A validator, returning Err if one is already set.
-    pub fn try_with_archival_validator(mut self, archival: Archival) -> Result<Self, Archival> {
-        self.validators = self.validators.try_with_archival_validator(archival)?;
-        Ok(self)
-    }
-
-    /// Set the PDF/UA accessibility validator (overwrites if already set).
+    /// Set the PDF/UA accessibility validator, overwriting the current one if already set.
     pub fn with_accessibility_validator(mut self, ua: Accessibility) -> Self {
         self.validators = self.validators.with_accessibility_validator(ua);
         self
-    }
-
-    /// Set the PDF/UA accessibility validator, returning Err if one is already set.
-    pub fn try_with_accessibility_validator(
-        mut self,
-        ua: Accessibility,
-    ) -> Result<Self, Accessibility> {
-        self.validators = self.validators.try_with_accessibility_validator(ua)?;
-        Ok(self)
     }
 
     /// Build the [`Configuration`], returning an error if the validators and version are incompatible.
@@ -161,18 +129,6 @@ mod tests {
 
     #[test]
     fn invalid_combination_2() {
-        // Same standard family: second try_with_archival_validator returns Err.
-        assert_eq!(
-            ConfigurationBuilder::new()
-                .try_with_archival_validator(Archival::A2_B)
-                .unwrap()
-                .try_with_archival_validator(Archival::A3_B),
-            Err(Archival::A2_B)
-        );
-    }
-
-    #[test]
-    fn invalid_combination_3() {
         // A4 requires PDF 2.0; UA1 max is PDF 1.7 → no overlapping range.
         assert!(matches!(
             ConfigurationBuilder::new()
@@ -184,19 +140,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_combination_4() {
-        // Duplicate (same validator).
-        assert_eq!(
-            ConfigurationBuilder::new()
-                .try_with_archival_validator(Archival::A3_B)
-                .unwrap()
-                .try_with_archival_validator(Archival::A3_B),
-            Err(Archival::A3_B)
-        );
-    }
-
-    #[test]
-    fn invalid_combination_5() {
+    fn invalid_combination_3() {
         // A1_B max is PDF 1.4; UA1 max is PDF 1.7 → intersection is PDF14..=PDF14.
         // Explicitly setting PDF 1.7 is out of range.
         assert!(matches!(

--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -308,7 +308,7 @@ impl IntoIterator for Validators {
 pub struct ValidatorsBuilder(Validators);
 
 impl ValidatorsBuilder {
-    /// Set a validator (overwrites if same standard family already set).
+    /// Set a validator, overwriting the current one if the same standard family is already set.
     pub fn set_validator(self, validator: Validator) -> Self {
         match validator {
             Validator::A(a) => self.with_archival_validator(a),
@@ -316,51 +316,16 @@ impl ValidatorsBuilder {
         }
     }
 
-    /// Set a validator, returning `Err` with the existing value if that standard family is already set.
-    pub fn set_validator_once(self, validator: Validator) -> Result<Self, Validator> {
-        match validator {
-            Validator::A(a) => self.try_with_archival_validator(a).map_err(Into::into),
-            Validator::Ua(ua) => self
-                .try_with_accessibility_validator(ua)
-                .map_err(Into::into),
-        }
-    }
-
-    /// Set the PDF/A validator (overwrites if already set).
+    /// Set the PDF/A validator, overwriting the current one if already set.
     pub fn with_archival_validator(mut self, archival: Archival) -> Self {
         self.0.a = Some(archival);
         self
     }
 
-    /// Set the PDF/A validator, returning `Err` with the existing value if one is already set.
-    pub fn try_with_archival_validator(mut self, archival: Archival) -> Result<Self, Archival> {
-        match self.0.a {
-            Some(a) => Err(a),
-            None => {
-                self.0.a = Some(archival);
-                Ok(self)
-            }
-        }
-    }
-
-    /// Set the PDF/UA accessibility validator (overwrites if already set).
+    /// Set the PDF/UA accessibility validator, overwriting the current one if already set.
     pub fn with_accessibility_validator(mut self, accessibility: Accessibility) -> Self {
         self.0.ua = Some(accessibility);
         self
-    }
-
-    /// Set the PDF/UA accessibility validator, returning `Err` with the existing value if one is already set.
-    pub fn try_with_accessibility_validator(
-        mut self,
-        accessibility: Accessibility,
-    ) -> Result<Self, Accessibility> {
-        match self.0.ua {
-            Some(ua) => Err(ua),
-            None => {
-                self.0.ua = Some(accessibility);
-                Ok(self)
-            }
-        }
     }
 
     pub(crate) fn finish(self) -> Result<Validators, Validators> {


### PR DESCRIPTION
After briefly discussing with @reknih, I would be in favor of removing those since they just bloat the API surface IMO. If clients want to have validation, it should be done on their side.