### PR TITLE
Remove the temporary `start_alt_text` and `end_alt_text` methods

### DIFF
--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -30,7 +30,7 @@ use crate::paint::{InnerPaint, Paint};
 use crate::pdf::PdfDocument;
 use crate::serialize::SerializeContext;
 use crate::stream::{Stream, StreamBuilder};
-use crate::tagging::{ArtifactType, SpanTag};
+use crate::tagging::ArtifactType;
 use crate::text::Font;
 use crate::text::{draw_glyph, Glyph};
 #[cfg(feature = "simple-text")]
@@ -214,27 +214,6 @@ impl<'a> Surface<'a> {
         } else {
             Identifier::dummy()
         }
-    }
-
-    /// A temporary hacky method to support alt text in Typst. Will be removed in the future.
-    #[doc(hidden)]
-    pub fn start_alt_text(&mut self, text: &str) {
-        let tag = ContentTag::Span(SpanTag {
-            lang: None,
-            alt_text: Some(text),
-            expanded: None,
-            actual_text: None,
-        });
-
-        self.bd
-            .get_mut()
-            .start_marked_content_with_properties(self.sc, None, tag);
-    }
-
-    /// A temporary hacky method to support alt text in Typst. Will be removed in the future.
-    #[doc(hidden)]
-    pub fn end_alt_text(&mut self) {
-        self.bd.get_mut().end_marked_content();
     }
 
     /// End the current tagged section.


### PR DESCRIPTION
Just to clean things up for #386

The macos CI failure seems a little spurious.