### PR TITLE
Always use correct page root transform for artifact bbox

### DIFF
--- a/crates/krilla-tests/src/tagging.rs
+++ b/crates/krilla-tests/src/tagging.rs
@@ -5,6 +5,7 @@ use krilla::annotation::{LinkAnnotation, Target};
 use krilla::error::KrillaError;
 use krilla::geom::{PathBuilder, Point, Rect, Size, Transform};
 use krilla::metadata::Metadata;
+use krilla::num::NormalizedF32;
 use krilla::outline::Outline;
 use krilla::page::PageSettings;
 use krilla::paint::{Fill, Stroke};
@@ -526,6 +527,24 @@ fn tagging_artifact_subtypes(document: &mut Document) {
     )));
     surface.outline_text_(100.0, "++");
     surface.end_tagged();
+
+    surface.finish();
+    page.finish();
+}
+
+#[snapshot(document)]
+fn tagging_artifact_with_bbox_in_xobject(document: &mut Document) {
+    let mut page = document.start_page();
+    let mut surface = page.surface();
+
+    surface.push_opacity(NormalizedF32::new(0.5).unwrap());
+    surface.start_tagged(ContentTag::Artifact(Artifact::new(
+        ArtifactType::Background,
+        Some(Rect::from_xywh(1.0, 88.0, 21.0, 10.0).unwrap()),
+    )));
+    surface.outline_text_(100.0, "++");
+    surface.end_tagged();
+    surface.pop();
 
     surface.finish();
     page.finish();

--- a/crates/krilla/src/content.rs
+++ b/crates/krilla/src/content.rs
@@ -127,6 +127,7 @@ impl ContentBuilder {
     pub(crate) fn start_marked_content_with_properties(
         &mut self,
         sc: &mut SerializeContext,
+        page_root_transform: Transform,
         mcid: Option<i32>,
         tag: ContentTag,
     ) {
@@ -141,10 +142,7 @@ impl ContentBuilder {
             properties.pairs([(Name(b"MCID"), mcid)]);
         }
 
-        // Page height extracted from transform and passed to function to allow
-        // its dependants to flip the y-axis, mirroring Krilla conventions.
-        let page_height = self.root_transform.ty();
-        tag.write_properties(sc, properties, page_height);
+        tag.write_properties(sc, properties, page_root_transform);
     }
 
     pub(crate) fn end_marked_content(&mut self) {
@@ -158,6 +156,10 @@ impl ContentBuilder {
 
     pub(crate) fn concat_transform(&mut self, transform: &Transform) {
         self.graphics_states.transform(*transform);
+    }
+
+    pub(crate) fn root_transform(&self) -> Transform {
+        self.root_transform
     }
 
     fn cur_transform_with_root_transform(&self) -> Transform {

--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -140,7 +140,7 @@ use crate::chunk_container::ChunkContainer;
 use crate::configure::validate::VersionedFeature;
 use crate::configure::{PdfVersion, ValidationError};
 use crate::error::{KrillaError, KrillaResult};
-use crate::geom::Rect;
+use crate::geom::{Rect, Transform};
 use crate::page::page_root_transform;
 use crate::serialize::SerializeContext;
 
@@ -311,7 +311,7 @@ impl ContentTag<'_> {
         &self,
         sc: &mut SerializeContext,
         mut properties: PropertyList,
-        page_height: f32,
+        page_root_transform: Transform,
     ) {
         match self {
             ContentTag::Artifact(artifact) => {
@@ -321,8 +321,7 @@ impl ContentTag<'_> {
                 let mut artifact_props = properties.artifact();
 
                 if let Some(bbox) = artifact.bbox {
-                    let transform = page_root_transform(page_height);
-                    let actual_rect = bbox.transform(transform).unwrap();
+                    let actual_rect = bbox.transform(page_root_transform).unwrap();
                     artifact_props.bounding_box(actual_rect.to_pdf_rect());
                 }
 

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -176,6 +176,10 @@ impl<'a> Surface<'a> {
     /// Panics if a tagged section has already been started.
     pub fn start_tagged(&mut self, tag: ContentTag) -> Identifier {
         if let Some(id) = &mut self.page_identifier {
+            // Since this surface has a page identifier, the root builder
+            // transform is the page root transform.
+            let page_root_tranform = self.bd.root_builder.root_transform();
+
             match tag {
                 // An artifact is actually not really part of tagged PDF and doesn't have
                 // a marked content identifier, so we need to return a dummy one here. It's just
@@ -193,9 +197,12 @@ impl<'a> Surface<'a> {
                     }
 
                     if artifact.requires_properties(self.sc.serialize_settings().pdf_version()) {
-                        self.bd
-                            .get_mut()
-                            .start_marked_content_with_properties(self.sc, None, tag);
+                        self.bd.get_mut().start_marked_content_with_properties(
+                            self.sc,
+                            page_root_tranform,
+                            None,
+                            tag,
+                        );
                     } else {
                         self.bd.get_mut().start_marked_content(tag.name());
                     }
@@ -205,6 +212,7 @@ impl<'a> Surface<'a> {
                 ContentTag::Span(_) | ContentTag::Other => {
                     self.bd.get_mut().start_marked_content_with_properties(
                         self.sc,
+                        page_root_tranform,
                         Some(id.mcid),
                         tag,
                     );

--- a/refs/snapshots/tagging_artifact_with_bbox_in_xobject.txt
+++ b/refs/snapshots/tagging_artifact_with_bbox_in_xobject.txt
@@ -74,7 +74,7 @@ endobj
 >>
 stream
 /Artifact <<
-  /BBox [1 -98 22 -88]
+  /BBox [1 744 22 754]
   /Type /Background
 >> BDC
 q
@@ -137,7 +137,7 @@ trailer
 <<
   /Size 9
   /Root 8 0 R
-  /ID [(ujliZzK1CuRXAI8aZGBtqQ==) (ujliZzK1CuRXAI8aZGBtqQ==)]
+  /ID [(N8FiufAJ7KRMafSBIAiCng==) (N8FiufAJ7KRMafSBIAiCng==)]
 >>
 startxref
 1224

--- a/refs/snapshots/tagging_artifact_with_bbox_in_xobject.txt
+++ b/refs/snapshots/tagging_artifact_with_bbox_in_xobject.txt
@@ -1,0 +1,144 @@
+%PDF-1.7
+%AAAA
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [5 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /ExtGState
+  /ca 0.5
+  /CA 0.5
+>>
+endobj
+
+3 0 obj
+<<
+  /ProcSet [/PDF /Text /ImageC /ImageB]
+>>
+endobj
+
+4 0 obj
+<<
+  /ProcSet [/PDF /Text /ImageC /ImageB]
+  /ExtGState <<
+    /g0 2 0 R
+  >>
+  /XObject <<
+    /x0 7 0 R
+  >>
+>>
+endobj
+
+5 0 obj
+<<
+  /Type /Page
+  /Resources 4 0 R
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 6 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Length 35
+>>
+stream
+q
+1 0 0 -1 0 842 cm
+/g0 gs
+/x0 Do
+Q
+endstream
+endobj
+
+7 0 obj
+<<
+  /Length 412
+  /Type /XObject
+  /Subtype /Form
+  /Resources 3 0 R
+  /BBox [1 88.1 21.84 97.78]
+  /Group <<
+    /Type /Group
+    /S /Transparency
+    /I true
+    /CS /DeviceRGB
+  >>
+>>
+stream
+/Artifact <<
+  /BBox [1 -98 22 -88]
+  /Type /Background
+>> BDC
+q
+0 g
+6.42 92.24 m
+10.4 92.24 l
+10.4 93.66 l
+6.42 93.66 l
+6.42 97.78 l
+4.98 97.78 l
+4.98 93.66 l
+1 93.66 l
+1 92.24 l
+4.98 92.24 l
+4.98 88.1 l
+6.42 88.1 l
+h
+f
+Q
+q
+0 g
+17.86 92.24 m
+21.84 92.24 l
+21.84 93.66 l
+17.86 93.66 l
+17.86 97.78 l
+16.42 97.78 l
+16.42 93.66 l
+12.440001 93.66 l
+12.440001 92.24 l
+16.42 92.24 l
+16.42 88.1 l
+17.86 88.1 l
+h
+f
+Q
+EMC
+endstream
+endobj
+
+8 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+>>
+endobj
+
+xref
+0 9
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000141 00000 n
+0000000203 00000 n
+0000000333 00000 n
+0000000448 00000 n
+0000000536 00000 n
+0000001170 00000 n
+trailer
+<<
+  /Size 9
+  /Root 8 0 R
+  /ID [(ujliZzK1CuRXAI8aZGBtqQ==) (ujliZzK1CuRXAI8aZGBtqQ==)]
+>>
+startxref
+1224
+%%EOF


### PR DESCRIPTION
Depends on #385

As mentioned in https://github.com/LaurenzV/krilla/pull/273#discussion_r3246334591, any `push` operation on the surface that would cause a builder to be inserted into the `sub_builders` array would use the identity `root_tranform` of the sub builder instead of the page root transform inside the `root_builder`.

(No idea why the macos CI is failing)