### PR TITLE
Make some helper methods public

### DIFF
--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -394,6 +394,22 @@ impl Validator {
             Self::Ua(ua) => ua.requires_xmp_metadata(),
         }
     }
+
+    /// Minimum PDF version required to use this validator, if any.
+    pub fn min(self) -> Option<PdfVersion> {
+        match self {
+            Self::A(a) => a.min(),
+            Self::Ua(ua) => ua.min(),
+        }
+    }
+
+    /// Maximum PDF version this standard can be used with.
+    pub fn max(self) -> PdfVersion {
+        match self {
+            Self::A(a) => a.max(),
+            Self::Ua(ua) => ua.max(),
+        }
+    }
 }
 
 impl From<Archival> for Validator {
@@ -961,7 +977,8 @@ impl Archival {
         }
     }
 
-    const fn min(self) -> Option<PdfVersion> {
+    /// Minimum PDF version required to use this standard, if any.
+    pub const fn min(self) -> Option<PdfVersion> {
         match self {
             // PDF/A-1 through 3 require XMP `/Metadata` streams, which require PDF 1.4.
             Self::A1_A | Self::A1_B => Some(PdfVersion::Pdf14),
@@ -971,7 +988,8 @@ impl Archival {
         }
     }
 
-    const fn max(self) -> PdfVersion {
+    /// Maximum PDF version this standard can be used with.
+    pub const fn max(self) -> PdfVersion {
         match self {
             Self::A1_A | Self::A1_B => PdfVersion::Pdf14,
             Self::A2_A | Self::A2_B | Self::A2_U | Self::A3_A | Self::A3_B | Self::A3_U => {
@@ -1153,14 +1171,16 @@ impl Accessibility {
         }
     }
 
-    const fn min(self) -> Option<PdfVersion> {
+    /// Minimum PDF version required to use this standard, if any.
+    pub const fn min(self) -> Option<PdfVersion> {
         match self {
             // PDF/UA-1 requires Tagged PDF and XMP `/Metadata` streams, which both require PDF 1.4.
             Self::UA1 => Some(PdfVersion::Pdf14),
         }
     }
 
-    const fn max(self) -> PdfVersion {
+    /// Maximum PDF version this standard can be used with.
+    pub const fn max(self) -> PdfVersion {
         match self {
             // PDF/UA-1 is specified against PDF 1.7.
             Self::UA1 => PdfVersion::Pdf17,

--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -410,6 +410,14 @@ impl Validator {
             Self::Ua(ua) => ua.max(),
         }
     }
+
+    /// Returns a human-readable string representation of the validator.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::A(a) => a.as_str(),
+            Self::Ua(ua) => ua.as_str(),
+        }
+    }
 }
 
 impl From<Archival> for Validator {

--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -370,7 +370,7 @@ impl ValidatorsBuilder {
 }
 
 /// A PDF validator for a specific conformance standard.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Validator {
     /// A PDF/A validator.
     A(Archival),

--- a/crates/krilla/src/configure/validate.rs
+++ b/crates/krilla/src/configure/validate.rs
@@ -189,6 +189,11 @@ impl Validators {
         self.a.is_none() && self.ua.is_none()
     }
 
+    /// Returns the number of set validators.
+    pub fn len(self) -> usize {
+        (if self.a.is_some() { 1 } else { 0 }) + (if self.ua.is_some() { 1 } else { 0 })
+    }
+
     /// Returns the PDF/A validator, if set.
     pub fn archival(self) -> Option<Archival> {
         self.a


### PR DESCRIPTION
This PR contains a few utilities meant to make integration in Typst 0.15, especially with regards to error formatting, easier.