### PR TITLE
Soften requirement for Artifact bboxes

### DIFF
--- a/crates/krilla/src/interchange/tagging/mod.rs
+++ b/crates/krilla/src/interchange/tagging/mod.rs
@@ -162,13 +162,10 @@ pub struct Artifact {
 impl Artifact {
     /// Create a new artifact with a type and an optional BBox.
     ///
-    /// This will panic if the artifact type is `Background` and no bounding box
-    /// is provided.
+    /// You must provide a bounding box if `kind` is
+    /// [`ArtifactType::Background`] and you are targetting PDF 1.7, otherwise,
+    /// Krilla will later panic.
     pub fn new(kind: ArtifactType, bbox: Option<Rect>) -> Self {
-        if kind == ArtifactType::Background && bbox.is_none() {
-            panic!("Background artifacts must have a bounding box");
-        }
-
         Self { kind, bbox }
     }
 
@@ -185,6 +182,17 @@ impl Artifact {
                 .map_pdf_version(pdf_version)
                 .to_pdf_artifact_type()
                 .is_some()
+    }
+
+    /// Whether the artifact requires a BBox.
+    pub(crate) fn requires_bbox(self, pdf_version: PdfVersion) -> bool {
+        // Background artifacts were introduced in PDF 1.7. In table 330, the
+        // standard makes bounding boxes mandatory for background artifacts
+        // only. PDF 2.0 lifts this requirement in table 363.
+        //
+        // When changing the below condition, also change the error at the
+        // callsite.
+        self.kind == ArtifactType::Background && pdf_version == PdfVersion::Pdf17
     }
 }
 

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -174,6 +174,7 @@ impl<'a> Surface<'a> {
     ///
     /// # Panics
     /// Panics if a tagged section has already been started.
+    /// Panics if an artifact with a required bbox has none.
     pub fn start_tagged(&mut self, tag: ContentTag) -> Identifier {
         if let Some(id) = &mut self.page_identifier {
             match tag {
@@ -201,6 +202,12 @@ impl<'a> Surface<'a> {
                             .start_marked_content_with_properties(self.sc, None, tag);
                     } else {
                         self.bd.get_mut().start_marked_content(tag.name());
+                    }
+
+                    if artifact.requires_bbox(self.sc.serialize_settings().pdf_version())
+                        && artifact.bbox.is_none()
+                    {
+                        panic!("Background artifact must have a bounding box in PDF 1.7");
                     }
 
                     Identifier::dummy()


### PR DESCRIPTION
Krilla previously asked for bounding boxes for all background artifacts, independent of PDF version. This type was introduced in PDF 1.7, but its mandate to come with BBoxes has been lifted by PDF 2.0.

Confer the Adobe-published edition of PDF 32000-1:2008, Table 330, and ISO 32000-2:2020(E), Table 363.

In practice, at least in Typst, the bounding box is not readily available for some background artifacts. Instead of writing the whole page to write something, we'd rather write nothing in PDF 2.0 in these cases.

If this is not the right spot to panic, happy to move or remove this check altogether.