### PR TITLE
Support custom document information fields

### DIFF
--- a/crates/krilla/src/interchange/metadata.rs
+++ b/crates/krilla/src/interchange/metadata.rs
@@ -130,7 +130,7 @@ impl Metadata {
     /// document information fields.
     ///
     /// **WARNING**: Custom fields will currently be ignored when exporting to
-    /// PDF/A-2 and PDF/A-3. This is a temporary limitation that will be lifted
+    /// PDF/A-2 and PDF/A-3 and PDF/A-4. This is a temporary limitation that will be lifted
     /// in the future.
     #[must_use]
     pub fn custom_field(mut self, name: String, value: String) -> Option<Self> {

--- a/crates/krilla/src/interchange/metadata.rs
+++ b/crates/krilla/src/interchange/metadata.rs
@@ -126,16 +126,19 @@ impl Metadata {
     /// Add a custom field to the document information dictionary.
     ///
     /// If a field with the same name was already added, its value will be
-    /// replaced. Empty names and names reserved for standard document
-    /// information fields are ignored. Custom fields are not included in the
-    /// XMP metadata. PDF/A-2 and PDF/A-3 readers may ignore the document
-    /// information dictionary, and export modes that prohibit the dictionary
-    /// will omit these fields.
-    pub fn custom_field(mut self, name: String, value: String) -> Self {
-        if !name.is_empty() && !is_standard_document_info_field(&name) {
-            self.custom_fields.insert(name, value);
+    /// replaced. Returns `None` for empty names and names reserved for standard
+    /// document information fields. 
+    /// 
+    /// Currently, custom fields are not included in the XMP
+    /// metadata and will fail export in  PDF/A-2 and PDF/A-3.
+    #[must_use]
+    pub fn custom_field(mut self, name: String, value: String) -> Option<Self> {
+        if name.is_empty() || is_standard_document_info_field(&name) {
+            return None;
         }
-        self
+
+        self.custom_fields.insert(name, value);
+        Some(self)
     }
 
     pub(crate) fn has_document_info(&self) -> bool {
@@ -509,5 +512,31 @@ impl PageLayout {
             PageLayout::TwoPageLeft => pdf_writer::types::PageLayout::TwoPageLeft,
             PageLayout::TwoPageRight => pdf_writer::types::PageLayout::TwoPageRight,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Metadata;
+
+    #[test]
+    fn custom_field_returns_none_for_ignored_names() {
+        assert!(Metadata::new()
+            .custom_field(String::new(), "value".to_string())
+            .is_none());
+        assert!(Metadata::new()
+            .custom_field("Title".to_string(), "value".to_string())
+            .is_none());
+
+        let metadata = Metadata::new()
+            .custom_field("CustomField".to_string(), "value".to_string())
+            .unwrap();
+        assert_eq!(
+            metadata
+                .custom_fields
+                .get("CustomField")
+                .map(String::as_str),
+            Some("value")
+        );
     }
 }

--- a/crates/krilla/src/interchange/metadata.rs
+++ b/crates/krilla/src/interchange/metadata.rs
@@ -9,7 +9,7 @@ use pdf_writer::{Finish, Name, Pdf, Ref, TextStr};
 use std::{cell::LazyCell, collections::BTreeMap};
 use xmp_writer::{LangId, Timezone, XmpWriter};
 
-use crate::configure::{Configuration, PdfVersion, ValidationError};
+use crate::configure::{Archival, Configuration, PdfVersion, ValidationError};
 use crate::serialize::SerializeContext;
 
 /// Metadata for a PDF document.
@@ -127,10 +127,11 @@ impl Metadata {
     ///
     /// If a field with the same name was already added, its value will be
     /// replaced. Returns `None` for empty names and names reserved for standard
-    /// document information fields. 
-    /// 
-    /// Currently, custom fields are not included in the XMP
-    /// metadata and will fail export in  PDF/A-2 and PDF/A-3.
+    /// document information fields.
+    ///
+    /// **WARNING**: Custom fields will currently be ignored when exporting to
+    /// PDF/A-2 and PDF/A-3. This is a temporary limitation that will be lifted
+    /// in the future.
     #[must_use]
     pub fn custom_field(mut self, name: String, value: String) -> Option<Self> {
         if name.is_empty() || is_standard_document_info_field(&name) {
@@ -313,8 +314,22 @@ impl Metadata {
                 document_info.creation_date(pdf_date(date_time));
             }
 
-            for (name, value) in &self.custom_fields {
-                document_info.pair(Name(name.as_bytes()), TextStr(value));
+            // This is temporary until custom fields can be written to XMP.
+            // See https://github.com/LaurenzV/krilla/pull/419#issuecomment-5142992957.
+            if !matches!(
+                config.validators().archival(),
+                Some(
+                    Archival::A2_A
+                        | Archival::A2_B
+                        | Archival::A2_U
+                        | Archival::A3_A
+                        | Archival::A3_B
+                        | Archival::A3_U
+                )
+            ) {
+                for (name, value) in &self.custom_fields {
+                    document_info.pair(Name(name.as_bytes()), TextStr(value));
+                }
             }
         }
     }

--- a/crates/krilla/src/interchange/metadata.rs
+++ b/crates/krilla/src/interchange/metadata.rs
@@ -5,8 +5,8 @@
 //! in the document via [`Document::set_metadata`].
 //!
 //! [`Document::set_metadata`]: crate::document::Document::set_metadata
-use pdf_writer::{Finish, Pdf, Ref, TextStr};
-use std::cell::LazyCell;
+use pdf_writer::{Finish, Name, Pdf, Ref, TextStr};
+use std::{cell::LazyCell, collections::BTreeMap};
 use xmp_writer::{LangId, Timezone, XmpWriter};
 
 use crate::configure::{Configuration, PdfVersion, ValidationError};
@@ -26,6 +26,7 @@ pub struct Metadata {
     pub(crate) creation_date: Option<DateTime>,
     pub(crate) text_direction: Option<TextDirection>,
     pub(crate) page_layout: Option<PageLayout>,
+    pub(crate) custom_fields: BTreeMap<String, String>,
 }
 
 impl Metadata {
@@ -122,6 +123,21 @@ impl Metadata {
         self
     }
 
+    /// Add a custom field to the document information dictionary.
+    ///
+    /// If a field with the same name was already added, its value will be
+    /// replaced. Empty names and names reserved for standard document
+    /// information fields are ignored. Custom fields are not included in the
+    /// XMP metadata. PDF/A-2 and PDF/A-3 readers may ignore the document
+    /// information dictionary, and export modes that prohibit the dictionary
+    /// will omit these fields.
+    pub fn custom_field(mut self, name: String, value: String) -> Self {
+        if !name.is_empty() && !is_standard_document_info_field(&name) {
+            self.custom_fields.insert(name, value);
+        }
+        self
+    }
+
     pub(crate) fn has_document_info(&self) -> bool {
         self.title.is_some()
             || self.producer.is_some()
@@ -130,6 +146,7 @@ impl Metadata {
             || self.creator.is_some()
             || self.creation_date.is_some()
             || self.description.is_some()
+            || !self.custom_fields.is_empty()
     }
 
     pub(crate) fn serialize_xmp_metadata(
@@ -292,8 +309,27 @@ impl Metadata {
                 document_info.modified_date(pdf_date(date_time));
                 document_info.creation_date(pdf_date(date_time));
             }
+
+            for (name, value) in &self.custom_fields {
+                document_info.pair(Name(name.as_bytes()), TextStr(value));
+            }
         }
     }
+}
+
+fn is_standard_document_info_field(name: &str) -> bool {
+    matches!(
+        name,
+        "Title"
+            | "Author"
+            | "Subject"
+            | "Keywords"
+            | "Creator"
+            | "Producer"
+            | "CreationDate"
+            | "ModDate"
+            | "Trapped"
+    )
 }
 
 /// A datetime. Invalid values will be clamped.

--- a/refs/snapshots/metadata_custom_fields.txt
+++ b/refs/snapshots/metadata_custom_fields.txt
@@ -1,0 +1,70 @@
+%PDF-1.7
+%AAAA
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [3 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /ProcSet [/PDF /Text /ImageC /ImageB]
+>>
+endobj
+
+3 0 obj
+<<
+  /Type /Page
+  /Resources 2 0 R
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 4 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Length 0
+>>
+stream
+
+endstream
+endobj
+
+5 0 obj
+<<
+  /Title (Standard title)
+  /Custom#2FKey (Custom value)
+  /CustomField (new value)
+>>
+endobj
+
+6 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+>>
+endobj
+
+xref
+0 7
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000142 00000 n
+0000000257 00000 n
+0000000309 00000 n
+0000000415 00000 n
+trailer
+<<
+  /Size 7
+  /Root 6 0 R
+  /Info 5 0 R
+  /ID [(uyRME0rdnAZhRI1o1IY/Aw==) (uyRME0rdnAZhRI1o1IY/Aw==)]
+>>
+startxref
+469
+%%EOF

--- a/refs/snapshots/validate_metadata_custom_fields_pdf_a1.txt
+++ b/refs/snapshots/validate_metadata_custom_fields_pdf_a1.txt
@@ -1,0 +1,135 @@
+%PDF-1.4
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [5 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /OutputIntent
+  /DestOutputProfile 7 0 R
+  /S /GTS_PDFA1
+  /OutputConditionIdentifier (Custom)
+  /OutputCondition (sRGB)
+  /RegistryName ()
+  /Info (sRGB v2.1)
+>>
+endobj
+
+3 0 obj
+[2 0 R]
+endobj
+
+4 0 obj
+<<
+  /ProcSet [/PDF /Text /ImageC /ImageB]
+>>
+endobj
+
+5 0 obj
+<<
+  /Type /Page
+  /Resources 4 0 R
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 6 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Length 0
+>>
+stream
+
+endstream
+endobj
+
+7 0 obj
+<<
+  /Length 1296
+  /N 3
+  /Range [0 1 0 1 0 1]
+  /Filter [/ASCIIHexDecode /FlateDecode]
+>>
+stream
+789C7D907B48530114C6CFDDDD9CD335E7A365396D5BABC4474F33E9A1A639CB47B839
+2B4DB479951939DD76AF696448A1E156B2C2126B9561A699612A614465494B5384A298
+D4049BF5C720B0468B85E0A37B9DB0F54F1F1CBE1F1F07CE0380662DC354388D0BA02A
+27B4B2D424C1D1DC3C01F32BA010042CE040A802C3D599D9123990C21555384668CBE0
+1F392700A1FC6374A9A2BCB8A93FA68BD32BD2B7CCDF787457A933C2FFC52A2EC131D2
+ED6415626A2D0180B0496657116A8A83490ED2924B911C45B1D2C5891417B958BED423
+9725935C4A56B5D2838B3C78791625064E1EEBB90851524D509E9CBC05A81FB852877C
+E9368437EACE2AEE00C4FD02400DEEACA819E0890E20D8E2CEC4649F5F3DC08009ABD4
+9E5A1E3340161FE2400E6AB804F7C104D30820224482A8906BC81062A7096839B48B34
+138AA009E8797498CEA1E7D23BE9B38C0C463B63C12BDF6B902964EA99BFBD316F33EB
+20EBB54F82CF4BDF24DF51B69C3DBD82E0B0386D7E897E566EBD7FB4BF25401F181FE8
+0CEA5FA9E1C5F2E6578D055F5F5DBE461222E2A37C5BE8FBB0176B7B04EDC2DBA29BEB
+5AC5F7D6F76D78B5D11C3E13E1131919258DAED9F460F3D456DE36D9F6AB319F63C53B
+F1B8E15D82DD357BBEC4A724F4EE132635EFE7A61852030E18D3C2D39F654A0FFDC832
+C876645B732E1F49C985BCC1FCBA828CE3218A9FD848498752774273B25025AD48D348
+F0B44A6955C169CD9986B31DB56FCFD9EBC22E6435E8F46F1A5906E995D62647737A4B
+B79173ABBAD5D676AC7DA2F370D7E44365CF9F3EC3E38881F1A7C473E1A079A8D19431
+C21DB58C77BFABFD906FDEFB493C193045B72E7C9BB321DFD9337C7B8C23CB89CF1AE7
+C61617FF02C1B1D707
+endstream
+endobj
+
+8 0 obj
+<<
+  /Title (Standard title)
+  /ModDate (D:20241108222318+01'12)
+  /CreationDate (D:20241108222318+01'12)
+  /Custom#2FKey (Custom value)
+  /CustomField (new value)
+>>
+endobj
+
+9 0 obj
+<<
+  /Length 3787
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Standard title</rdf:li></rdf:Alt></dc:title><xmp:ModifyDate>2024-11-08T22:23:18+01:12</xmp:ModifyDate><xmp:CreateDate>2024-11-08T22:23:18+01:12</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2024-11-08T22:23:18+01:12</stEvt:when></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2024-11-08T22:23:18+01:12</stEvt:when></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>1</pdfaid:part><pdfaid:conformance>B</pdfaid:conformance><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>ZbE9/HLEBoLB0nM7uSOwNA==</xmpMM:InstanceID><xmpMM:DocumentID>ZbE9/HLEBoLB0nM7uSOwNA==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.4</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+10 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 9 0 R
+  /OutputIntents 3 0 R
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000270 00000 n
+0000000294 00000 n
+0000000356 00000 n
+0000000471 00000 n
+0000000523 00000 n
+0000001945 00000 n
+0000002128 00000 n
+0000006004 00000 n
+trailer
+<<
+  /Size 11
+  /Root 10 0 R
+  /Info 8 0 R
+  /ID [(ZbE9/HLEBoLB0nM7uSOwNA==) (ZbE9/HLEBoLB0nM7uSOwNA==)]
+>>
+startxref
+6100
+%%EOF

--- a/refs/snapshots/validate_metadata_custom_fields_pdf_a2.txt
+++ b/refs/snapshots/validate_metadata_custom_fields_pdf_a2.txt
@@ -1,0 +1,124 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [5 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /OutputIntent
+  /DestOutputProfile 7 0 R
+  /S /GTS_PDFA1
+  /OutputConditionIdentifier (Custom)
+  /OutputCondition (sRGB)
+  /RegistryName ()
+  /Info (sRGB v4.2)
+>>
+endobj
+
+3 0 obj
+[2 0 R]
+endobj
+
+4 0 obj
+<<
+  /ProcSet [/PDF /Text /ImageC /ImageB]
+>>
+endobj
+
+5 0 obj
+<<
+  /Type /Page
+  /Resources 4 0 R
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 6 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Length 0
+>>
+stream
+
+endstream
+endobj
+
+7 0 obj
+<<
+  /Length 649
+  /N 3
+  /Range [0 1 0 1 0 1]
+  /Filter [/ASCIIHexDecode /FlateDecode]
+>>
+stream
+789C7D90BD4BC35014C54FAC5A95AA831D1C1482162705D1C549A1957612A11FD2D629
+79E98790C4981729CEDAC1497110477511C4B98E76F00F100407511037D70A3A6889F7
+3542AAA0F772B93F0EF7C2E100D293CE0CDE290386E9D8C94454CEE6F272F0190184D1
+8B018C2A8C5B4BA9781A545CA970E6D83A7ED4DB1D24B16FA7CA8AA96DBD5CADE4E7A5
+DAF67835137F5F3EC7FFD5A71538A3FD49136196ED00924C3C56712CC18BC461565634
+E22CF1A44D068977845EF2F848B0EAF185603B9D8C11D789E5521BAB6D6CE89BECDB83
+701F2A989914ED1E9A1170249140F48F9BEED64D8C7A1A1079FDCE81176767BCAFD002
+D0F5E8BAAF1340701F681EB8EEC789EB364F81C00350DFF0FFD78F81B906E97BBEA61E
+0297BBC0F0BDAF45E86EB00AD4AE2DC5565A5280A6A3B80634CE80FE1C307443D1AE7E
+01E3E25FB1
+endstream
+endobj
+
+8 0 obj
+<<
+  /Title (Standard title)
+  /ModDate (D:20241108222318+01'12)
+  /CreationDate (D:20241108222318+01'12)
+>>
+endobj
+
+9 0 obj
+<<
+  /Length 3923
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Standard title</rdf:li></rdf:Alt></dc:title><xmp:ModifyDate>2024-11-08T22:23:18+01:12</xmp:ModifyDate><xmp:CreateDate>2024-11-08T22:23:18+01:12</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2024-11-08T22:23:18+01:12</stEvt:when><stEvt:instanceID>b1MphRTfBI5UMk9nX3PYmw==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2024-11-08T22:23:18+01:12</stEvt:when><stEvt:instanceID>b1MphRTfBI5UMk9nX3PYmw==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>2</pdfaid:part><pdfaid:conformance>B</pdfaid:conformance><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>b1MphRTfBI5UMk9nX3PYmw==</xmpMM:InstanceID><xmpMM:DocumentID>b1MphRTfBI5UMk9nX3PYmw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+10 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 9 0 R
+  /OutputIntents 3 0 R
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000270 00000 n
+0000000294 00000 n
+0000000356 00000 n
+0000000471 00000 n
+0000000523 00000 n
+0000001297 00000 n
+0000001422 00000 n
+0000005434 00000 n
+trailer
+<<
+  /Size 11
+  /Root 10 0 R
+  /Info 8 0 R
+  /ID [(b1MphRTfBI5UMk9nX3PYmw==) (b1MphRTfBI5UMk9nX3PYmw==)]
+>>
+startxref
+5530
+%%EOF

--- a/refs/snapshots/validate_metadata_custom_fields_pdf_a3.txt
+++ b/refs/snapshots/validate_metadata_custom_fields_pdf_a3.txt
@@ -1,0 +1,124 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [5 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /OutputIntent
+  /DestOutputProfile 7 0 R
+  /S /GTS_PDFA1
+  /OutputConditionIdentifier (Custom)
+  /OutputCondition (sRGB)
+  /RegistryName ()
+  /Info (sRGB v4.2)
+>>
+endobj
+
+3 0 obj
+[2 0 R]
+endobj
+
+4 0 obj
+<<
+  /ProcSet [/PDF /Text /ImageC /ImageB]
+>>
+endobj
+
+5 0 obj
+<<
+  /Type /Page
+  /Resources 4 0 R
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 6 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Length 0
+>>
+stream
+
+endstream
+endobj
+
+7 0 obj
+<<
+  /Length 649
+  /N 3
+  /Range [0 1 0 1 0 1]
+  /Filter [/ASCIIHexDecode /FlateDecode]
+>>
+stream
+789C7D90BD4BC35014C54FAC5A95AA831D1C1482162705D1C549A1957612A11FD2D629
+79E98790C4981729CEDAC1497110477511C4B98E76F00F100407511037D70A3A6889F7
+3542AAA0F772B93F0EF7C2E100D293CE0CDE290386E9D8C94454CEE6F272F0190184D1
+8B018C2A8C5B4BA9781A545CA970E6D83A7ED4DB1D24B16FA7CA8AA96DBD5CADE4E7A5
+DAF67835137F5F3EC7FFD5A71538A3FD49136196ED00924C3C56712CC18BC461565634
+E22CF1A44D068977845EF2F848B0EAF185603B9D8C11D789E5521BAB6D6CE89BECDB83
+701F2A989914ED1E9A1170249140F48F9BEED64D8C7A1A1079FDCE81176767BCAFD002
+D0F5E8BAAF1340701F681EB8EEC789EB364F81C00350DFF0FFD78F81B906E97BBEA61E
+0297BBC0F0BDAF45E86EB00AD4AE2DC5565A5280A6A3B80634CE80FE1C307443D1AE7E
+01E3E25FB1
+endstream
+endobj
+
+8 0 obj
+<<
+  /Title (Standard title)
+  /ModDate (D:20241108222318+01'12)
+  /CreationDate (D:20241108222318+01'12)
+>>
+endobj
+
+9 0 obj
+<<
+  /Length 3923
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Standard title</rdf:li></rdf:Alt></dc:title><xmp:ModifyDate>2024-11-08T22:23:18+01:12</xmp:ModifyDate><xmp:CreateDate>2024-11-08T22:23:18+01:12</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2024-11-08T22:23:18+01:12</stEvt:when><stEvt:instanceID>b1MphRTfBI5UMk9nX3PYmw==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2024-11-08T22:23:18+01:12</stEvt:when><stEvt:instanceID>b1MphRTfBI5UMk9nX3PYmw==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>3</pdfaid:part><pdfaid:conformance>B</pdfaid:conformance><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>b1MphRTfBI5UMk9nX3PYmw==</xmpMM:InstanceID><xmpMM:DocumentID>b1MphRTfBI5UMk9nX3PYmw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+10 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 9 0 R
+  /OutputIntents 3 0 R
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000270 00000 n
+0000000294 00000 n
+0000000356 00000 n
+0000000471 00000 n
+0000000523 00000 n
+0000001297 00000 n
+0000001422 00000 n
+0000005434 00000 n
+trailer
+<<
+  /Size 11
+  /Root 10 0 R
+  /Info 8 0 R
+  /ID [(b1MphRTfBI5UMk9nX3PYmw==) (b1MphRTfBI5UMk9nX3PYmw==)]
+>>
+startxref
+5530
+%%EOF

--- a/refs/snapshots/validate_metadata_custom_fields_pdf_a4.txt
+++ b/refs/snapshots/validate_metadata_custom_fields_pdf_a4.txt
@@ -1,0 +1,107 @@
+%PDF-2.0
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 1
+  /Kids [4 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /OutputIntent
+  /DestOutputProfile 6 0 R
+  /S /GTS_PDFA1
+  /OutputConditionIdentifier (Custom)
+  /OutputCondition (sRGB)
+  /RegistryName ()
+  /Info (sRGB v4.2)
+>>
+endobj
+
+3 0 obj
+[2 0 R]
+endobj
+
+4 0 obj
+<<
+  /Type /Page
+  /Resources <<>>
+  /MediaBox [0 0 595 842]
+  /Parent 1 0 R
+  /Contents 5 0 R
+>>
+endobj
+
+5 0 obj
+<<
+  /Length 0
+>>
+stream
+
+endstream
+endobj
+
+6 0 obj
+<<
+  /Length 649
+  /N 3
+  /Range [0 1 0 1 0 1]
+  /Filter [/ASCIIHexDecode /FlateDecode]
+>>
+stream
+789C7D90BD4BC35014C54FAC5A95AA831D1C1482162705D1C549A1957612A11FD2D629
+79E98790C4981729CEDAC1497110477511C4B98E76F00F100407511037D70A3A6889F7
+3542AAA0F772B93F0EF7C2E100D293CE0CDE290386E9D8C94454CEE6F272F0190184D1
+8B018C2A8C5B4BA9781A545CA970E6D83A7ED4DB1D24B16FA7CA8AA96DBD5CADE4E7A5
+DAF67835137F5F3EC7FFD5A71538A3FD49136196ED00924C3C56712CC18BC461565634
+E22CF1A44D068977845EF2F848B0EAF185603B9D8C11D789E5521BAB6D6CE89BECDB83
+701F2A989914ED1E9A1170249140F48F9BEED64D8C7A1A1079FDCE81176767BCAFD002
+D0F5E8BAAF1340701F681EB8EEC789EB364F81C00350DFF0FFD78F81B906E97BBEA61E
+0297BBC0F0BDAF45E86EB00AD4AE2DC5565A5280A6A3B80634CE80FE1C307443D1AE7E
+01E3E25FB1
+endstream
+endobj
+
+7 0 obj
+<<
+  /Length 1587
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Standard title</rdf:li></rdf:Alt></dc:title><xmp:ModifyDate>2024-11-08T22:23:18+01:12</xmp:ModifyDate><xmp:CreateDate>2024-11-08T22:23:18+01:12</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2024-11-08T22:23:18+01:12</stEvt:when><stEvt:instanceID>pw64mV2xwkBY/NVawFf8aQ==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2024-11-08T22:23:18+01:12</stEvt:when><stEvt:instanceID>pw64mV2xwkBY/NVawFf8aQ==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaid:part>4</pdfaid:part><pdfaid:rev>2020</pdfaid:rev><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>pw64mV2xwkBY/NVawFf8aQ==</xmpMM:InstanceID><xmpMM:DocumentID>pw64mV2xwkBY/NVawFf8aQ==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>2.0</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+8 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 7 0 R
+  /OutputIntents 3 0 R
+>>
+endobj
+
+xref
+0 9
+0000000000 65535 f
+0000000016 00000 n
+0000000080 00000 n
+0000000270 00000 n
+0000000294 00000 n
+0000000408 00000 n
+0000000460 00000 n
+0000001234 00000 n
+0000002910 00000 n
+trailer
+<<
+  /Size 9
+  /Root 8 0 R
+  /ID [(pw64mV2xwkBY/NVawFf8aQ==) (pw64mV2xwkBY/NVawFf8aQ==)]
+>>
+startxref
+3005
+%%EOF

--- a/tests/src/metadata.rs
+++ b/tests/src/metadata.rs
@@ -53,10 +53,12 @@ fn metadata_full_with_xmp(document: &mut Document) {
 fn metadata_custom_fields(document: &mut Document) {
     let metadata = Metadata::new()
         .title("Standard title".to_string())
-        .custom_field("Title".to_string(), "Custom title".to_string())
         .custom_field("CustomField".to_string(), "old value".to_string())
+        .unwrap()
         .custom_field("CustomField".to_string(), "new value".to_string())
-        .custom_field("Custom/Key".to_string(), "Custom value".to_string());
+        .unwrap()
+        .custom_field("Custom/Key".to_string(), "Custom value".to_string())
+        .unwrap();
     document.set_metadata(metadata);
 }
 

--- a/tests/src/metadata.rs
+++ b/tests/src/metadata.rs
@@ -2,7 +2,7 @@ use krilla::metadata::{DateTime, Metadata, PageLayout, TextDirection};
 use krilla::Document;
 use krilla_macros::snapshot;
 
-fn datetime() -> DateTime {
+pub(crate) fn datetime() -> DateTime {
     DateTime::new(2024)
         .month(11)
         .day(8)
@@ -51,15 +51,18 @@ fn metadata_full_with_xmp(document: &mut Document) {
 
 #[snapshot(document)]
 fn metadata_custom_fields(document: &mut Document) {
-    let metadata = Metadata::new()
+    document.set_metadata(custom_metadata());
+}
+
+pub(crate) fn custom_metadata() -> Metadata {
+    Metadata::new()
         .title("Standard title".to_string())
         .custom_field("CustomField".to_string(), "old value".to_string())
         .unwrap()
         .custom_field("CustomField".to_string(), "new value".to_string())
         .unwrap()
         .custom_field("Custom/Key".to_string(), "Custom value".to_string())
-        .unwrap();
-    document.set_metadata(metadata);
+        .unwrap()
 }
 
 #[snapshot(document, settings_30)]

--- a/tests/src/metadata.rs
+++ b/tests/src/metadata.rs
@@ -49,6 +49,17 @@ fn metadata_full_with_xmp(document: &mut Document) {
     metadata_impl(document);
 }
 
+#[snapshot(document)]
+fn metadata_custom_fields(document: &mut Document) {
+    let metadata = Metadata::new()
+        .title("Standard title".to_string())
+        .custom_field("Title".to_string(), "Custom title".to_string())
+        .custom_field("CustomField".to_string(), "old value".to_string())
+        .custom_field("CustomField".to_string(), "new value".to_string())
+        .custom_field("Custom/Key".to_string(), "Custom value".to_string());
+    document.set_metadata(metadata);
+}
+
 #[snapshot(document, settings_30)]
 fn metadata_pdf_20_author(document: &mut Document) {
     let metadata = Metadata::new()

--- a/tests/src/validate.rs
+++ b/tests/src/validate.rs
@@ -18,6 +18,7 @@ use krilla::text::{GlyphId, KrillaGlyph};
 use krilla_macros::snapshot;
 
 use crate::embed::{embedded_file_impl, file_1};
+use crate::metadata::{custom_metadata, datetime};
 use crate::{
     blue_fill, cmyk_fill, dummy_text_with_spans, green_fill, load_jpg_image, load_png_image, loc,
     metadata_1, metadata_2, rect_to_path, red_fill, settings_1, settings_13, settings_15,
@@ -450,6 +451,30 @@ fn validate_pdfa_private_unicode_codepoint() {
             None
         )]
     )
+}
+
+fn custom_metadata_validation_impl(document: &mut Document) {
+    document.set_metadata(custom_metadata().creation_date(datetime()));
+}
+
+#[snapshot(document, settings_19)]
+fn validate_metadata_custom_fields_pdf_a1(document: &mut Document) {
+    custom_metadata_validation_impl(document);
+}
+
+#[snapshot(document, settings_7)]
+fn validate_metadata_custom_fields_pdf_a2(document: &mut Document) {
+    custom_metadata_validation_impl(document);
+}
+
+#[snapshot(document, settings_10)]
+fn validate_metadata_custom_fields_pdf_a3(document: &mut Document) {
+    custom_metadata_validation_impl(document);
+}
+
+#[snapshot(document, settings_26)]
+fn validate_metadata_custom_fields_pdf_a4(document: &mut Document) {
+    custom_metadata_validation_impl(document);
 }
 
 #[snapshot(document, settings_20)]


### PR DESCRIPTION
PDF document information dictionaries can contain application-defined entries, but `Metadata` currently exposes only the standard fields.

Add `Metadata::custom_field` for writing custom text entries through `pdf-writer`'s document information dictionary API. Repeated field names replace their earlier values, while empty names and names reserved for standard document information fields are ignored.

Custom information fields remain separate from XMP metadata. Custom XMP properties and namespace handling are covered independently by #408.