### PR TITLE
Re-export `usvg`

### DIFF
--- a/crates/krilla-svg/src/lib.rs
+++ b/crates/krilla-svg/src/lib.rs
@@ -20,6 +20,9 @@ use krilla::surface::Surface;
 use krilla::text::GlyphId;
 use usvg::{fontdb, roxmltree, Node, Tree};
 
+/// Re-export of `usvg`.
+pub use usvg;
+
 use crate::text::Fonts;
 use crate::util::RectExt;
 


### PR DESCRIPTION
So that clients don't have to pull it in themselves.