### PR TITLE
Fix typos in comments

### DIFF
--- a/crates/krilla/src/chunk_container.rs
+++ b/crates/krilla/src/chunk_container.rs
@@ -121,7 +121,7 @@ impl ChunkContainer {
 
         // Chunk length is not an exact number because the length might change as we renumber,
         // so we add a bit of a padding by multiplying with 1.1. The 200 is additional padding
-        // for the document catalog. This hopefully allows us to avoid re-alloactions in the general
+        // for the document catalog. This hopefully allows us to avoid re-allocations in the general
         // case, and thus give us better performance.
         let capacity = (chunks_byte_len as f32 * 1.1 + 200.0) as usize;
         let mut pdf = sc.new_pdf_with_capacity(capacity);

--- a/crates/krilla/src/surface.rs
+++ b/crates/krilla/src/surface.rs
@@ -108,7 +108,7 @@ impl<'a> Surface<'a> {
     /// Set the fill that should be used for the next drawing operation.
     ///
     /// You can set it to `None` if you want to disable filling (though
-    /// if there is no active stroke, than krilla will choose to fill
+    /// if there is no active stroke, then krilla will choose to fill
     /// with black by default).
     pub fn set_fill(&mut self, fill: Option<Fill>) {
         self.fill = fill;


### PR DESCRIPTION
Keeping as draft in case I find more while I am working on pdf forms